### PR TITLE
feat: callout support and default theme improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dist
 .pnp.*
 
 dist
+examples/frontier

--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "react-device-detect": "^2.2.3",
         "react-dom": "^19.0.0",
         "remark-attr": "^0.11.1",
+        "remark-directive": "^4.0.0",
         "slugify": "^1.6.6",
         "yaml": "^2.8.2",
         "zod": "^4.3.6",
@@ -586,6 +587,8 @@
 
     "md-attr-parser": ["md-attr-parser@1.3.0", "", {}, "sha512-KTVlfU5Oxo/6kd0YZ2mLP3eWJj+5vzh5mBCxLo3yGl1fzHIgxmtadbE9tHb7TbUBi3XZbl+P0xKeGmakat135w=="],
 
+    "mdast-util-directive": ["mdast-util-directive@3.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "parse-entities": "^4.0.0", "stringify-entities": "^4.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q=="],
+
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
     "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA=="],
@@ -621,6 +624,8 @@
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
     "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-directive": ["micromark-extension-directive@4.0.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "parse-entities": "^4.0.0" } }, "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg=="],
 
     "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
 
@@ -755,6 +760,8 @@
     "remark": ["remark@15.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A=="],
 
     "remark-attr": ["remark-attr@0.11.1", "", { "dependencies": { "html-element-attributes": "^2.0.0", "is-whitespace-character": "^1.0.4", "md-attr-parser": "^1.3.0", "remark-footnotes": "^1.0.0" } }, "sha512-NnzURvBJ52c58L3AohBk5qSTBPXdMKsf5+w9L0YNhi/HCtv7ZA9dNRz5NsPIxLtIHhoZIjTqQsMzoyggyPVvkQ=="],
+
+    "remark-directive": ["remark-directive@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-directive": "^3.0.0", "micromark-extension-directive": "^4.0.0", "unified": "^11.0.0" } }, "sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA=="],
 
     "remark-footnotes": ["remark-footnotes@1.0.0", "", {}, "sha512-X9Ncj4cj3/CIvLI2Z9IobHtVi8FVdUrdJkCNaL9kdX8ohfsi18DXHsCVd/A7ssARBdccdDb5ODnt62WuEWaM/g=="],
 

--- a/packages/chronicle/package.json
+++ b/packages/chronicle/package.json
@@ -40,6 +40,7 @@
     "react-device-detect": "^2.2.3",
     "react-dom": "^19.0.0",
     "remark-attr": "^0.11.1",
+    "remark-directive": "^4.0.0",
     "slugify": "^1.6.6",
     "yaml": "^2.8.2",
     "zod": "^4.3.6"

--- a/packages/chronicle/source.config.ts
+++ b/packages/chronicle/source.config.ts
@@ -5,6 +5,6 @@ const contentDir = process.env.CHRONICLE_CONTENT_DIR || './content'
 export const docs = defineDocs({
   dir: contentDir,
   docs: {
-    files: ['**/*.mdx', '!**/node_modules/**'],
+    files: ['**/*.mdx', '**/*.md', '!**/node_modules/**'],
   },
 })

--- a/packages/chronicle/source.config.ts
+++ b/packages/chronicle/source.config.ts
@@ -1,4 +1,6 @@
-import { defineDocs } from 'fumadocs-mdx/config'
+import { defineDocs, defineConfig } from 'fumadocs-mdx/config'
+import remarkDirective from 'remark-directive'
+import { remarkDirectiveAdmonition } from 'fumadocs-core/mdx-plugins'
 
 const contentDir = process.env.CHRONICLE_CONTENT_DIR || './content'
 
@@ -6,5 +8,33 @@ export const docs = defineDocs({
   dir: contentDir,
   docs: {
     files: ['**/*.mdx', '**/*.md', '!**/node_modules/**'],
+  },
+})
+
+export default defineConfig({
+  mdxOptions: {
+    remarkPlugins: [
+      remarkDirective,
+      [
+        remarkDirectiveAdmonition,
+        {
+          tags: {
+            CalloutContainer: 'Callout',
+            CalloutTitle: 'CalloutTitle',
+            CalloutDescription: 'CalloutDescription',
+          },
+          types: {
+            note: 'accent',
+            tip: 'accent',
+            info: 'accent',
+            warn: 'attention',
+            warning: 'attention',
+            danger: 'alert',
+            caution: 'alert',
+            success: 'success',
+          },
+        },
+      ],
+    ],
   },
 })

--- a/packages/chronicle/src/app/[[...slug]]/page.tsx
+++ b/packages/chronicle/src/app/[[...slug]]/page.tsx
@@ -26,7 +26,7 @@ export default async function DocsPage({ params }: PageProps) {
     notFound()
   }
 
-  const { Layout, Page } = getTheme(config.theme?.name)
+  const { Layout, Page, className } = getTheme(config.theme?.name)
 
   const data = page.data as PageData
   const MDXBody = data.body
@@ -34,7 +34,7 @@ export default async function DocsPage({ params }: PageProps) {
   const tree = buildPageTree()
 
   return (
-    <Layout config={config} tree={tree}>
+    <Layout config={config} tree={tree} classNames={{ layout: className }}>
       <Page
         page={{
           slug: slug ?? [],

--- a/packages/chronicle/src/app/apis/[[...slug]]/layout.tsx
+++ b/packages/chronicle/src/app/apis/[[...slug]]/layout.tsx
@@ -1,3 +1,4 @@
+import { cx } from 'class-variance-authority'
 import { loadConfig } from '@/lib/config'
 import { loadApiSpecs } from '@/lib/openapi'
 import { buildApiPageTree } from '@/lib/api-routes'
@@ -7,13 +8,13 @@ import styles from './layout.module.css'
 
 export default function ApiLayout({ children }: { children: React.ReactNode }) {
   const config = loadConfig()
-  const { Layout } = getTheme(config.theme?.name)
+  const { Layout, className } = getTheme(config.theme?.name)
   const specs = loadApiSpecs(config.api ?? [])
   const tree = buildApiPageTree(specs)
 
   return (
     <Layout config={config} tree={tree} classNames={{
-      layout: styles.layout,
+      layout: cx(styles.layout, className),
       body: styles.body,
       sidebar: styles.sidebar,
       content: styles.content,

--- a/packages/chronicle/src/components/common/callout.module.css
+++ b/packages/chronicle/src/components/common/callout.module.css
@@ -1,0 +1,3 @@
+.callout {
+  margin: var(--rs-space-5) 0;
+}

--- a/packages/chronicle/src/components/common/callout.tsx
+++ b/packages/chronicle/src/components/common/callout.tsx
@@ -1,3 +1,27 @@
 'use client'
 
-export { Callout } from '@raystack/apsara'
+import React from 'react'
+import { Callout } from '@raystack/apsara'
+import styles from './callout.module.css'
+
+function CalloutContainer(props: React.ComponentProps<typeof Callout>) {
+  return <Callout outline width="100%" className={styles.callout} {...props} />
+}
+
+function CalloutTitle({ children }: { children: React.ReactNode }) {
+  return <strong>{children}</strong>
+}
+
+function CalloutDescription({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}
+
+function MdxBlockquote(props: React.ComponentProps<'blockquote'>) {
+  return (
+    <Callout type="grey" outline width="100%" className={styles.callout}>
+      {props.children}
+    </Callout>
+  )
+}
+
+export { Callout, CalloutContainer, CalloutTitle, CalloutDescription, MdxBlockquote }

--- a/packages/chronicle/src/components/mdx/code.module.css
+++ b/packages/chronicle/src/components/mdx/code.module.css
@@ -9,7 +9,7 @@
   padding: var(--rs-space-3) var(--rs-space-4);
   background: var(--rs-color-background-base-secondary);
   border-bottom: 1px solid var(--rs-color-border-base);
-  font-size: var(--rs-font-size-1);
+  font-size: var(--rs-font-size-mini);
   color: var(--rs-color-text-base-secondary);
 }
 
@@ -21,7 +21,7 @@
 }
 
 .pre code {
-  font-family: var(--rs-font-family-mono);
-  font-size: var(--rs-font-size-2);
+  font-family: var(--rs-font-mono);
+  font-size: var(--rs-font-size-small);
   line-height: 1.6;
 }

--- a/packages/chronicle/src/components/mdx/index.tsx
+++ b/packages/chronicle/src/components/mdx/index.tsx
@@ -4,6 +4,7 @@ import { Link } from './link'
 import { MdxTable, MdxThead, MdxTbody, MdxTr, MdxTh, MdxTd } from './table'
 import { MdxPre } from './code'
 import { Callout } from '@/components/common/callout'
+import { Tabs } from '@raystack/apsara'
 
 export const mdxComponents: MDXComponents = {
   img: Image,
@@ -16,6 +17,7 @@ export const mdxComponents: MDXComponents = {
   td: MdxTd,
   pre: MdxPre,
   Callout,
+  Tabs,
 }
 
 export { Image } from './image'

--- a/packages/chronicle/src/components/mdx/index.tsx
+++ b/packages/chronicle/src/components/mdx/index.tsx
@@ -3,7 +3,7 @@ import { Image } from './image'
 import { Link } from './link'
 import { MdxTable, MdxThead, MdxTbody, MdxTr, MdxTh, MdxTd } from './table'
 import { MdxPre } from './code'
-import { Callout } from '@/components/common/callout'
+import { CalloutContainer, CalloutTitle, CalloutDescription, MdxBlockquote } from '@/components/common/callout'
 import { Tabs } from '@raystack/apsara'
 
 export const mdxComponents: MDXComponents = {
@@ -16,7 +16,10 @@ export const mdxComponents: MDXComponents = {
   th: MdxTh,
   td: MdxTd,
   pre: MdxPre,
-  Callout,
+  blockquote: MdxBlockquote,
+  Callout: CalloutContainer,
+  CalloutTitle,
+  CalloutDescription,
   Tabs,
 }
 

--- a/packages/chronicle/src/themes/default/Page.module.css
+++ b/packages/chronicle/src/themes/default/Page.module.css
@@ -5,8 +5,30 @@
 .article {
   flex: 1;
   min-width: 0;
+  max-width: 768px;
 }
 
 .content {
   line-height: 1.7;
+}
+
+.content h1,
+.content h2,
+.content h3,
+.content h4,
+.content h5,
+.content h6 {
+  margin-top: var(--rs-space-8);
+  margin-bottom: var(--rs-space-5);
+}
+
+.content ul,
+.content ol {
+  padding-left: var(--rs-space-5);
+}
+
+.content table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
 }

--- a/packages/chronicle/src/themes/default/Toc.module.css
+++ b/packages/chronicle/src/themes/default/Toc.module.css
@@ -22,6 +22,7 @@
   gap: 0;
   border-left: 1px solid var(--rs-color-border-base-primary);
   padding-left: var(--rs-space-3);
+  margin-bottom: var(--rs-space-6);
 }
 
 .link {

--- a/packages/chronicle/src/themes/default/font.ts
+++ b/packages/chronicle/src/themes/default/font.ts
@@ -1,0 +1,6 @@
+import { Inter } from 'next/font/google'
+
+export const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+})

--- a/packages/chronicle/src/themes/default/index.ts
+++ b/packages/chronicle/src/themes/default/index.ts
@@ -1,11 +1,13 @@
 import { Layout } from './Layout'
 import { Page } from './Page'
 import { Toc } from './Toc'
+import { inter } from './font'
 import type { Theme } from '@/types'
 
 export const defaultTheme: Theme = {
   Layout,
   Page,
+  className: inter.className,
 }
 
 export { Layout, Page, Toc }

--- a/packages/chronicle/src/types/theme.ts
+++ b/packages/chronicle/src/types/theme.ts
@@ -18,4 +18,5 @@ export interface ThemePageProps {
 export interface Theme {
   Layout: React.ComponentType<ThemeLayoutProps>
   Page: React.ComponentType<ThemePageProps>
+  className?: string
 }


### PR DESCRIPTION
## Summary
- Add `remark-directive` + `remarkDirectiveAdmonition` for `:::note`/`:::warning`/`:::caution` callout syntax mapped to Apsara Callout components
- Plain blockquotes render as grey outlined callouts
- Add per-theme font support with Inter for default theme
- Add content typography and layout styles for default theme
- Fix invalid CSS font vars (`--rs-font-size-2` → `--rs-font-size-small`, `--rs-font-family-mono` → `--rs-font-mono`)
- Add md glob support and register Tabs MDX component

## Test plan
- [ ] Verify `:::warning` / `:::note` / `:::caution` render as styled Apsara Callouts
- [ ] Verify plain `>` blockquotes render as grey callouts
- [ ] Verify code blocks have correct font-family and font-size
- [ ] Verify default theme typography and layout styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)