### PR TITLE
fix: switch to bun publish for npm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,15 +32,10 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           npm version "$VERSION" --no-git-tag-version --allow-same-version
 
-      - name: Create .npmrc
-        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > "$HOME/.npmrc"
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Publish
-        run: npm publish --access public
+        run: bun publish --access public
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   docker-release:
     name: Publish to Docker Hub

--- a/packages/chronicle/package.json
+++ b/packages/chronicle/package.json
@@ -4,6 +4,14 @@
   "description": "Config-driven documentation framework",
   "license": "Apache-2.0",
   "type": "module",
+  "files": [
+    "bin",
+    "dist",
+    "src",
+    "templates",
+    "next.config.mjs",
+    "source.config.ts"
+  ],
   "bin": {
     "chronicle": "./bin/chronicle.js"
   },


### PR DESCRIPTION
## Summary
- Replace `npm publish` with `bun publish` to fix `Cannot read properties of null (reading 'matches')` error
- Add `files` field to `packages/chronicle/package.json` to explicitly scope published contents
- Remove unnecessary `.npmrc` creation step; `bun publish` uses `NPM_CONFIG_TOKEN` env var directly

## Test plan
- [x] Verified with `bun publish --dry-run` locally (117 files, 0.48MB)
- [ ] Trigger a release to verify end-to-end publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)