### PR TITLE
fix: replace npm version with bump-version script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,9 @@ jobs:
         run: bun build-cli.ts
 
       - name: Bump version
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          npm version "$VERSION" --no-git-tag-version --allow-same-version
+        run: bun scripts/bump-version.ts
+        env:
+          GIT_REFNAME: ${{ github.ref_name }}
 
       - name: Publish
         run: bun publish --access public

--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,9 @@
         "@types/node": "^25.1.0",
         "@types/react": "^19.2.10",
         "@types/react-dom": "^19.2.3",
+        "@types/semver": "^7.7.1",
         "openapi-types": "^12.1.3",
+        "semver": "^7.7.4",
         "typescript": "5.9.3",
       },
     },
@@ -512,6 +514,8 @@
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 

--- a/packages/chronicle/package.json
+++ b/packages/chronicle/package.json
@@ -26,7 +26,9 @@
     "@types/node": "^25.1.0",
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",
+    "@types/semver": "^7.7.1",
     "openapi-types": "^12.1.3",
+    "semver": "^7.7.4",
     "typescript": "5.9.3"
   },
   "dependencies": {

--- a/packages/chronicle/scripts/bump-version.ts
+++ b/packages/chronicle/scripts/bump-version.ts
@@ -1,0 +1,15 @@
+import { valid, compare } from "semver"
+import fs from "fs/promises"
+import path from "path"
+
+const pkgPath = path.join(import.meta.dir, "../package.json")
+const pkg = await Bun.file(pkgPath).json()
+
+const gitRef = process.env.GIT_REFNAME
+const gitTag = valid(gitRef)
+
+if (gitTag && compare(gitTag, pkg.version) > 0) {
+  pkg.version = gitTag
+  console.log("Updating version to", gitTag)
+  await fs.writeFile(pkgPath, JSON.stringify(pkg, null, 2))
+}


### PR DESCRIPTION
## Summary
- Add `scripts/bump-version.ts` using `semver` to bump package version from git tag
- Replace `npm version` step (which was hanging) with `bun scripts/bump-version.ts`
- Add `semver` and `@types/semver` as devDependencies

## Test plan
- [x] Tested locally: `GIT_REFNAME=v0.2.0 bun scripts/bump-version.ts` correctly updates version
- [ ] Trigger a release to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)