### PR TITLE
feat: add --config flag for chronicle.yaml path

### DIFF
--- a/packages/chronicle/src/cli/commands/build.ts
+++ b/packages/chronicle/src/cli/commands/build.ts
@@ -1,18 +1,20 @@
 import chalk from 'chalk';
 import { Command } from 'commander';
-import { resolveContentDir } from '@/cli/utils/config';
+import { resolveConfigPath, resolveContentDir } from '@/cli/utils/config';
 import { PACKAGE_ROOT } from '@/cli/utils/resolve';
 import { linkContent } from '@/cli/utils/scaffold';
 
 export const buildCommand = new Command('build')
   .description('Build for production')
-  .option('-c, --content <path>', 'Content directory')
+  .option('--content <path>', 'Content directory')
+  .option('--config <path>', 'Path to chronicle.yaml')
   .option(
     '--preset <preset>',
     'Deploy preset (vercel, cloudflare, node-server)'
   )
   .action(async options => {
     const contentDir = resolveContentDir(options.content);
+    const configPath = resolveConfigPath(options.config);
     await linkContent(contentDir);
 
     console.log(chalk.cyan('Building for production...'));
@@ -24,6 +26,7 @@ export const buildCommand = new Command('build')
       packageRoot: PACKAGE_ROOT,
       projectRoot: process.cwd(),
       contentDir,
+      configPath: configPath ?? undefined,
       preset: options.preset
     });
 

--- a/packages/chronicle/src/cli/commands/build.ts
+++ b/packages/chronicle/src/cli/commands/build.ts
@@ -26,7 +26,7 @@ export const buildCommand = new Command('build')
       packageRoot: PACKAGE_ROOT,
       projectRoot: process.cwd(),
       contentDir,
-      configPath: configPath ?? undefined,
+      configPath,
       preset: options.preset
     });
 

--- a/packages/chronicle/src/cli/commands/dev.ts
+++ b/packages/chronicle/src/cli/commands/dev.ts
@@ -2,16 +2,18 @@ import fs from 'node:fs';
 import path from 'node:path';
 import chalk from 'chalk';
 import { Command } from 'commander';
-import { resolveContentDir } from '@/cli/utils/config';
+import { resolveConfigPath, resolveContentDir } from '@/cli/utils/config';
 import { PACKAGE_ROOT } from '@/cli/utils/resolve';
 import { linkContent } from '@/cli/utils/scaffold';
 
 export const devCommand = new Command('dev')
   .description('Start development server')
   .option('-p, --port <port>', 'Port number', '3000')
-  .option('-c, --content <path>', 'Content directory')
+  .option('--content <path>', 'Content directory')
+  .option('--config <path>', 'Path to chronicle.yaml')
   .action(async options => {
     const contentDir = resolveContentDir(options.content);
+    const configPath = resolveConfigPath(options.config);
     const port = parseInt(options.port, 10);
 
     await linkContent(contentDir);
@@ -21,7 +23,7 @@ export const devCommand = new Command('dev')
     const { createServer } = await import('vite');
     const { createViteConfig } = await import('@/server/vite-config');
 
-    const config = await createViteConfig({ packageRoot: PACKAGE_ROOT, projectRoot: process.cwd(), contentDir });
+    const config = await createViteConfig({ packageRoot: PACKAGE_ROOT, projectRoot: process.cwd(), contentDir, configPath: configPath ?? undefined });
     const server = await createServer({
       ...config,
       server: { ...config.server, port }

--- a/packages/chronicle/src/cli/commands/dev.ts
+++ b/packages/chronicle/src/cli/commands/dev.ts
@@ -23,7 +23,7 @@ export const devCommand = new Command('dev')
     const { createServer } = await import('vite');
     const { createViteConfig } = await import('@/server/vite-config');
 
-    const config = await createViteConfig({ packageRoot: PACKAGE_ROOT, projectRoot: process.cwd(), contentDir, configPath: configPath ?? undefined });
+    const config = await createViteConfig({ packageRoot: PACKAGE_ROOT, projectRoot: process.cwd(), contentDir, configPath });
     const server = await createServer({
       ...config,
       server: { ...config.server, port }

--- a/packages/chronicle/src/cli/commands/serve.ts
+++ b/packages/chronicle/src/cli/commands/serve.ts
@@ -1,19 +1,21 @@
 import chalk from 'chalk';
 import { Command } from 'commander';
-import { resolveContentDir } from '@/cli/utils/config';
+import { resolveConfigPath, resolveContentDir } from '@/cli/utils/config';
 import { PACKAGE_ROOT } from '@/cli/utils/resolve';
 import { linkContent } from '@/cli/utils/scaffold';
 
 export const serveCommand = new Command('serve')
   .description('Build and start production server')
   .option('-p, --port <port>', 'Port number', '3000')
-  .option('-c, --content <path>', 'Content directory')
+  .option('--content <path>', 'Content directory')
+  .option('--config <path>', 'Path to chronicle.yaml')
   .option(
     '--preset <preset>',
     'Deploy preset (vercel, cloudflare, node-server)'
   )
   .action(async options => {
     const contentDir = resolveContentDir(options.content);
+    const configPath = resolveConfigPath(options.config);
     const port = parseInt(options.port, 10);
     await linkContent(contentDir);
 
@@ -24,6 +26,7 @@ export const serveCommand = new Command('serve')
       packageRoot: PACKAGE_ROOT,
       projectRoot: process.cwd(),
       contentDir,
+      configPath: configPath ?? undefined,
       preset: options.preset
     });
 

--- a/packages/chronicle/src/cli/commands/serve.ts
+++ b/packages/chronicle/src/cli/commands/serve.ts
@@ -26,7 +26,7 @@ export const serveCommand = new Command('serve')
       packageRoot: PACKAGE_ROOT,
       projectRoot: process.cwd(),
       contentDir,
-      configPath: configPath ?? undefined,
+      configPath,
       preset: options.preset
     });
 

--- a/packages/chronicle/src/cli/commands/start.ts
+++ b/packages/chronicle/src/cli/commands/start.ts
@@ -7,7 +7,7 @@ import { linkContent } from '@/cli/utils/scaffold';
 export const startCommand = new Command('start')
   .description('Start production server')
   .option('-p, --port <port>', 'Port number', '3000')
-  .option('-c, --content <path>', 'Content directory')
+  .option('--content <path>', 'Content directory')
   .action(async options => {
     const contentDir = resolveContentDir(options.content);
     const port = parseInt(options.port, 10);

--- a/packages/chronicle/src/cli/utils/config.ts
+++ b/packages/chronicle/src/cli/utils/config.ts
@@ -15,14 +15,15 @@ export function resolveContentDir(contentFlag?: string): string {
   return path.resolve('content');
 }
 
-function resolveConfigPath(): string | null {
+export function resolveConfigPath(configFlag?: string): string | null {
+  if (configFlag) return path.resolve(configFlag);
   const cwdPath = path.join(process.cwd(), 'chronicle.yaml');
   if (fs.existsSync(cwdPath)) return cwdPath;
   return null;
 }
 
-export function loadCLIConfig(contentDir: string): CLIConfig {
-  const configPath = resolveConfigPath();
+export function loadCLIConfig(contentDir: string, configFlag?: string): CLIConfig {
+  const configPath = resolveConfigPath(configFlag);
 
   if (!configPath) {
     console.log(

--- a/packages/chronicle/src/cli/utils/config.ts
+++ b/packages/chronicle/src/cli/utils/config.ts
@@ -20,19 +20,27 @@ export function resolveConfigPath(configPath?: string): string | undefined {
   return undefined;
 }
 
+async function readConfig(configPath: string): Promise<ChronicleConfig> {
+  try {
+    const raw = await fs.readFile(configPath, 'utf-8');
+    return parse(raw) as ChronicleConfig;
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === 'ENOENT') {
+      console.log(chalk.red(`Error: chronicle.yaml not found at '${configPath}'`));
+      console.log(chalk.gray("Run 'chronicle init' to create one"));
+    } else {
+      console.log(chalk.red(`Error: Invalid YAML in '${configPath}'`));
+      console.log(chalk.gray(err.message));
+    }
+    process.exit(1);
+  }
+}
+
 export async function loadCLIConfig(contentDir: string, configPath?: string): Promise<CLIConfig> {
   const resolvedConfigPath = resolveConfigPath(configPath)
     ?? path.join(process.cwd(), 'chronicle.yaml');
 
-  try {
-    const raw = await fs.readFile(resolvedConfigPath, 'utf-8');
-    const config = parse(raw) as ChronicleConfig;
-    return { config, configPath: resolvedConfigPath, contentDir };
-  } catch {
-    console.log(
-      chalk.red(`Error: chronicle.yaml not found at '${resolvedConfigPath}'`)
-    );
-    console.log(chalk.gray("Run 'chronicle init' to create one"));
-    process.exit(1);
-  }
+  const config = await readConfig(resolvedConfigPath);
+  return { config, configPath: resolvedConfigPath, contentDir };
 }

--- a/packages/chronicle/src/cli/utils/config.ts
+++ b/packages/chronicle/src/cli/utils/config.ts
@@ -15,17 +15,17 @@ export function resolveContentDir(contentFlag?: string): string {
   return path.resolve('content');
 }
 
-export function resolveConfigPath(configFlag?: string): string | null {
-  if (configFlag) return path.resolve(configFlag);
+export function resolveConfigPath(configPath?: string): string | undefined {
+  if (configPath) return path.resolve(configPath);
   const cwdPath = path.join(process.cwd(), 'chronicle.yaml');
   if (fs.existsSync(cwdPath)) return cwdPath;
-  return null;
+  return undefined;
 }
 
-export function loadCLIConfig(contentDir: string, configFlag?: string): CLIConfig {
-  const configPath = resolveConfigPath(configFlag);
+export function loadCLIConfig(contentDir: string, configPath?: string): CLIConfig {
+  const resolvedConfigPath = resolveConfigPath(configPath);
 
-  if (!configPath) {
+  if (!resolvedConfigPath) {
     console.log(
       chalk.red(
         `Error: chronicle.yaml not found in '${process.cwd()}'`
@@ -35,7 +35,7 @@ export function loadCLIConfig(contentDir: string, configFlag?: string): CLIConfi
     process.exit(1);
   }
 
-  const config = parse(fs.readFileSync(configPath, 'utf-8')) as ChronicleConfig;
+  const config = parse(fs.readFileSync(resolvedConfigPath, 'utf-8')) as ChronicleConfig;
 
-  return { config, configPath, contentDir };
+  return { config, configPath: resolvedConfigPath, contentDir };
 }

--- a/packages/chronicle/src/cli/utils/config.ts
+++ b/packages/chronicle/src/cli/utils/config.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs';
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import chalk from 'chalk';
 import { parse } from 'yaml';
@@ -17,25 +17,22 @@ export function resolveContentDir(contentFlag?: string): string {
 
 export function resolveConfigPath(configPath?: string): string | undefined {
   if (configPath) return path.resolve(configPath);
-  const cwdPath = path.join(process.cwd(), 'chronicle.yaml');
-  if (fs.existsSync(cwdPath)) return cwdPath;
   return undefined;
 }
 
-export function loadCLIConfig(contentDir: string, configPath?: string): CLIConfig {
-  const resolvedConfigPath = resolveConfigPath(configPath);
+export async function loadCLIConfig(contentDir: string, configPath?: string): Promise<CLIConfig> {
+  const resolvedConfigPath = resolveConfigPath(configPath)
+    ?? path.join(process.cwd(), 'chronicle.yaml');
 
-  if (!resolvedConfigPath) {
+  try {
+    const raw = await fs.readFile(resolvedConfigPath, 'utf-8');
+    const config = parse(raw) as ChronicleConfig;
+    return { config, configPath: resolvedConfigPath, contentDir };
+  } catch {
     console.log(
-      chalk.red(
-        `Error: chronicle.yaml not found in '${process.cwd()}'`
-      )
+      chalk.red(`Error: chronicle.yaml not found at '${resolvedConfigPath}'`)
     );
     console.log(chalk.gray("Run 'chronicle init' to create one"));
     process.exit(1);
   }
-
-  const config = parse(fs.readFileSync(resolvedConfigPath, 'utf-8')) as ChronicleConfig;
-
-  return { config, configPath: resolvedConfigPath, contentDir };
 }

--- a/packages/chronicle/src/cli/utils/config.ts
+++ b/packages/chronicle/src/cli/utils/config.ts
@@ -15,21 +15,19 @@ export function resolveContentDir(contentFlag?: string): string {
   return path.resolve('content');
 }
 
-function resolveConfigPath(contentDir: string): string | null {
+function resolveConfigPath(): string | null {
   const cwdPath = path.join(process.cwd(), 'chronicle.yaml');
   if (fs.existsSync(cwdPath)) return cwdPath;
-  const contentPath = path.join(contentDir, 'chronicle.yaml');
-  if (fs.existsSync(contentPath)) return contentPath;
   return null;
 }
 
 export function loadCLIConfig(contentDir: string): CLIConfig {
-  const configPath = resolveConfigPath(contentDir);
+  const configPath = resolveConfigPath();
 
   if (!configPath) {
     console.log(
       chalk.red(
-        `Error: chronicle.yaml not found in '${process.cwd()}' or '${contentDir}'`
+        `Error: chronicle.yaml not found in '${process.cwd()}'`
       )
     );
     console.log(chalk.gray("Run 'chronicle init' to create one"));

--- a/packages/chronicle/src/server/vite-config.ts
+++ b/packages/chronicle/src/server/vite-config.ts
@@ -19,26 +19,30 @@ export interface ViteConfigOptions {
   packageRoot: string;
   projectRoot: string;
   contentDir: string;
+  configPath?: string;
   preset?: string;
 }
 
-async function readChronicleConfig(projectRoot: string, contentDir: string): Promise<string | null> {
-  for (const dir of [projectRoot, contentDir]) {
-    const filePath = path.join(dir, 'chronicle.yaml');
+async function readChronicleConfig(projectRoot: string, configPath?: string): Promise<string | null> {
+  if (configPath) {
     try {
-      return await fs.readFile(filePath, 'utf-8');
+      return await fs.readFile(configPath, 'utf-8');
     } catch {
-      // not found, try next
+      return null;
     }
   }
-  return null;
+  try {
+    return await fs.readFile(path.join(projectRoot, 'chronicle.yaml'), 'utf-8');
+  } catch {
+    return null;
+  }
 }
 
 export async function createViteConfig(
   options: ViteConfigOptions
 ): Promise<InlineConfig> {
-  const { packageRoot, projectRoot, contentDir, preset } = options;
-  const rawConfig = await readChronicleConfig(projectRoot, contentDir);
+  const { packageRoot, projectRoot, contentDir, configPath, preset } = options;
+  const rawConfig = await readChronicleConfig(projectRoot, configPath);
 
   return {
     root: packageRoot,

--- a/packages/chronicle/src/server/vite-config.ts
+++ b/packages/chronicle/src/server/vite-config.ts
@@ -27,8 +27,8 @@ async function readChronicleConfig(projectRoot: string, configPath?: string): Pr
   if (configPath) {
     try {
       return await fs.readFile(configPath, 'utf-8');
-    } catch {
-      return null;
+    } catch (error) {
+      throw new Error(`Failed to read config file '${configPath}': ${(error as Error).message}`);
     }
   }
   try {


### PR DESCRIPTION
## Summary
- Add `--config <path>` flag to `dev`, `build`, and `serve` commands to specify chronicle.yaml location
- Remove `-c` short arg from `--content` across all commands to avoid future conflicts
- Config resolution: `--config` flag takes priority over cwd lookup; removed content dir fallback

## Test plan
- [x] Build CLI successfully
- [x] Verified `--help` shows `--config` option
- [x] Tested `--config` flag from different cwd — dev server starts with correct config

🤖 Generated with [Claude Code](https://claude.com/claude-code)