### PR TITLE
fix: center content with gutters in default theme

### DIFF
--- a/packages/chronicle/src/themes/default/Page.module.css
+++ b/packages/chronicle/src/themes/default/Page.module.css
@@ -1,5 +1,8 @@
 .page {
   gap: var(--rs-space-9);
+  max-width: 1024px;
+  margin: 0 auto;
+  width: 100%;
 }
 
 .article {


### PR DESCRIPTION
## Summary
- Center the page content (article + TOC) in the default theme layout with equal gutters on both sides
- Adds `max-width: 1024px`, `margin: 0 auto`, and `width: 100%` to `.page` container

## Test plan
- [ ] Run docs with `theme: default` and verify content is centered with gutters
- [ ] Verify sidebar remains fixed on the left
- [ ] Check responsive behavior at different viewport widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)