### PR TITLE
feat: add --host flag to CLI and fix Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,21 +17,22 @@ RUN chmod +x bin/chronicle.js
 RUN ln -s /app/packages/chronicle/bin/chronicle.js /usr/local/bin/chronicle
 
 # --- init project ---
-WORKDIR /docs
+WORKDIR /content
 RUN bun add /app/packages/chronicle
 RUN chronicle init
 
 # --- runner ---
 FROM base AS runner
-WORKDIR /docs
+WORKDIR /content
 
-COPY --from=builder /docs /docs
+COPY --from=builder /content /content
 COPY --from=builder /app/packages/chronicle /app/packages/chronicle
+COPY --from=builder /app/node_modules /app/node_modules
 RUN ln -s /app/packages/chronicle/bin/chronicle.js /usr/local/bin/chronicle
 
-VOLUME /docs/content
+VOLUME /content
 
 EXPOSE 3000
 
 ENTRYPOINT ["chronicle"]
-CMD ["serve", "--port", "3000"]
+CMD ["serve", "--port", "3000", "--host", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,11 @@ WORKDIR /content
 
 COPY --from=builder /content /content
 COPY --from=builder /app/packages/chronicle /app/packages/chronicle
-COPY --from=builder /app/node_modules /app/node_modules
+COPY --from=deps /app/package.json /app/bun.lock /app/
+COPY --from=deps /app/packages/chronicle/package.json /app/packages/chronicle/
+WORKDIR /app
+RUN bun install --production --frozen-lockfile
+WORKDIR /content
 RUN ln -s /app/packages/chronicle/bin/chronicle.js /usr/local/bin/chronicle
 
 VOLUME /content

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -40,6 +40,7 @@ chronicle dev [options]
 | `--content <path>` | Content directory | `content` |
 | `--config <path>` | Path to `chronicle.yaml` | `./chronicle.yaml` |
 | `-p, --port <port>` | Port number | `3000` |
+| `--host <host>` | Host address | `localhost` |
 
 ## build
 
@@ -67,6 +68,7 @@ chronicle start [options]
 |------|-------------|---------|
 | `--content <path>` | Content directory | `content` |
 | `-p, --port <port>` | Port number | `3000` |
+| `--host <host>` | Host address | `localhost` |
 
 ## serve
 
@@ -81,6 +83,7 @@ chronicle serve [options]
 | `--content <path>` | Content directory | `content` |
 | `--config <path>` | Path to `chronicle.yaml` | `./chronicle.yaml` |
 | `-p, --port <port>` | Port number | `3000` |
+| `--host <host>` | Host address | `localhost` |
 | `--preset <preset>` | Deploy preset (`vercel`, `cloudflare`, `node-server`) | — |
 
 ## Resolution Order

--- a/docs/docker.mdx
+++ b/docs/docker.mdx
@@ -19,23 +19,23 @@ docker pull raystack/chronicle
 The default command builds and starts a production server on port 3000.
 
 ```bash
-docker run -p 3000:3000 -v ./content:/docs/content raystack/chronicle
+docker run -p 3000:3000 -v ./content:/content raystack/chronicle
 ```
 
-Mount your content directory (containing MDX files) to `/docs/content`. Place `chronicle.yaml` in the content directory or it will use defaults.
+Mount your content directory (containing MDX files) to `/content`. Place `chronicle.yaml` in the content directory or it will use defaults.
 
 ## Development Server
 
 Override the default command with `dev` for hot reload:
 
 ```bash
-docker run -p 3000:3000 -v ./content:/docs/content raystack/chronicle dev --port 3000
+docker run -p 3000:3000 -v ./content:/content raystack/chronicle dev --port 3000
 ```
 
 ## Custom Port
 
 ```bash
-docker run -p 8080:8080 -v ./content:/docs/content raystack/chronicle serve --port 8080
+docker run -p 8080:8080 -v ./content:/content raystack/chronicle serve --port 8080
 ```
 
 ## Docker Compose
@@ -47,7 +47,7 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./content:/docs/content
+      - ./content:/content
 ```
 
 ## Available Commands
@@ -56,11 +56,11 @@ The entrypoint is `chronicle`, so any CLI command can be passed:
 
 ```bash
 # Build only
-docker run -v ./content:/docs/content raystack/chronicle build
+docker run -v ./content:/content raystack/chronicle build
 
 # Start pre-built server
-docker run -p 3000:3000 -v ./content:/docs/content raystack/chronicle start --port 3000
+docker run -p 3000:3000 -v ./content:/content raystack/chronicle start --port 3000
 
 # Build and start (default)
-docker run -p 3000:3000 -v ./content:/docs/content raystack/chronicle serve --port 3000
+docker run -p 3000:3000 -v ./content:/content raystack/chronicle serve --port 3000
 ```

--- a/packages/chronicle/src/cli/commands/dev.ts
+++ b/packages/chronicle/src/cli/commands/dev.ts
@@ -9,6 +9,7 @@ export const devCommand = new Command('dev')
   .option('-p, --port <port>', 'Port number', '3000')
   .option('--content <path>', 'Content directory')
   .option('--config <path>', 'Path to chronicle.yaml')
+  .option('--host <host>', 'Host address', 'localhost')
   .action(async options => {
     const { contentDir, configPath } = await loadCLIConfig(options.config, { content: options.content });
     const port = parseInt(options.port, 10);
@@ -23,7 +24,7 @@ export const devCommand = new Command('dev')
     const config = await createViteConfig({ packageRoot: PACKAGE_ROOT, projectRoot: process.cwd(), contentDir, configPath });
     const server = await createServer({
       ...config,
-      server: { ...config.server, port }
+      server: { ...config.server, port, host: options.host }
     });
 
     await server.listen();

--- a/packages/chronicle/src/cli/commands/serve.ts
+++ b/packages/chronicle/src/cli/commands/serve.ts
@@ -9,6 +9,7 @@ export const serveCommand = new Command('serve')
   .option('-p, --port <port>', 'Port number', '3000')
   .option('--content <path>', 'Content directory')
   .option('--config <path>', 'Path to chronicle.yaml')
+  .option('--host <host>', 'Host address', 'localhost')
   .option(
     '--preset <preset>',
     'Deploy preset (vercel, cloudflare, node-server)'
@@ -38,7 +39,7 @@ export const serveCommand = new Command('serve')
     console.log(chalk.cyan('Starting production server...'));
     const server = await preview({
       ...config,
-      preview: { port }
+      preview: { port, host: options.host }
     });
 
     server.printUrls();

--- a/packages/chronicle/src/cli/commands/start.ts
+++ b/packages/chronicle/src/cli/commands/start.ts
@@ -8,6 +8,7 @@ export const startCommand = new Command('start')
   .description('Start production server')
   .option('-p, --port <port>', 'Port number', '3000')
   .option('--content <path>', 'Content directory')
+  .option('--host <host>', 'Host address', 'localhost')
   .action(async options => {
     const { contentDir, configPath } = await loadCLIConfig(undefined, { content: options.content });
     const port = parseInt(options.port, 10);
@@ -21,7 +22,7 @@ export const startCommand = new Command('start')
     const config = await createViteConfig({ packageRoot: PACKAGE_ROOT, projectRoot: process.cwd(), contentDir, configPath });
     const server = await preview({
       ...config,
-      preview: { port }
+      preview: { port, host: options.host }
     });
 
     server.printUrls();


### PR DESCRIPTION
## Summary
- Add `--host` flag (default: `localhost`) to `dev`, `start`, and `serve` commands for Docker port mapping
- Fix Dockerfile: copy `node_modules` to runner stage (fixes `Cannot find module 'fumadocs-core/mdx-plugins'`)
- Change Docker working directory from `/docs` to `/content`

## Test plan
- [x] Docker build succeeds
- [x] `docker run -p 4000:3000 chronicle-test` returns HTTP 200
- [x] `--host 0.0.0.0` exposes network address in container
- [ ] `chronicle dev --host 0.0.0.0` works locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)