### PR TITLE
fix: copy README to package dir before npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
         env:
           GIT_REFNAME: ${{ github.ref_name }}
 
+      - name: Copy README
+        run: cp ../../README.md .
+
       - name: Publish
         run: bun publish --access public
         env:


### PR DESCRIPTION
## Summary
- Copies root `README.md` into `packages/chronicle/` before `npm publish` in the release workflow
- Fixes missing README on https://www.npmjs.com/package/@raystack/chronicle

## Test plan
- [x] Verified with `act release --dryrun` — workflow parses and runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)