### PR TITLE
fix: homepage rendering and client-side navigation issues

### DIFF
--- a/packages/chronicle/src/components/mdx/link.tsx
+++ b/packages/chronicle/src/components/mdx/link.tsx
@@ -1,24 +1,18 @@
 import { Link as ApsaraLink } from '@raystack/apsara';
-import type { ComponentProps } from 'react';
-import { Link as RouterLink } from 'react-router';
+import type { ComponentProps, MouseEvent } from 'react';
+import { useNavigate } from 'react-router';
 
 type LinkProps = ComponentProps<'a'>;
 
 export function Link({ href, children, ...props }: LinkProps) {
+  const navigate = useNavigate();
+
   if (!href) {
     return <span {...props}>{children}</span>;
   }
 
   const isExternal = href.startsWith('http://') || href.startsWith('https://');
   const isAnchor = href.startsWith('#');
-
-  if (isAnchor) {
-    return (
-      <ApsaraLink href={href} {...props}>
-        {children}
-      </ApsaraLink>
-    );
-  }
 
   if (isExternal) {
     return (
@@ -33,9 +27,22 @@ export function Link({ href, children, ...props }: LinkProps) {
     );
   }
 
+  if (isAnchor) {
+    return (
+      <ApsaraLink href={href} {...props}>
+        {children}
+      </ApsaraLink>
+    );
+  }
+
+  const onClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    navigate(href);
+  };
+
   return (
-    <RouterLink to={href} className={props.className}>
+    <ApsaraLink href={href} onClick={onClick} {...props}>
       {children}
-    </RouterLink>
+    </ApsaraLink>
   );
 }

--- a/packages/chronicle/src/components/mdx/link.tsx
+++ b/packages/chronicle/src/components/mdx/link.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router';
 
 type LinkProps = ComponentProps<'a'>;
 
-export function Link({ href, children, ...props }: LinkProps) {
+export function Link({ href, children, onClick: onClickProp, ...props }: LinkProps) {
   const navigate = useNavigate();
 
   if (!href) {
@@ -36,12 +36,26 @@ export function Link({ href, children, ...props }: LinkProps) {
   }
 
   const onClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    if (
+      e.defaultPrevented ||
+      e.button !== 0 ||
+      e.metaKey ||
+      e.ctrlKey ||
+      e.shiftKey ||
+      e.altKey
+    ) {
+      return;
+    }
+
+    onClickProp?.(e);
+    if (e.defaultPrevented) return;
+
     e.preventDefault();
     navigate(href);
   };
 
   return (
-    <ApsaraLink href={href} onClick={onClick} {...props}>
+    <ApsaraLink href={href} {...props} onClick={onClick}>
       {children}
     </ApsaraLink>
   );

--- a/packages/chronicle/src/pages/DocsPage.tsx
+++ b/packages/chronicle/src/pages/DocsPage.tsx
@@ -30,7 +30,7 @@ export function DocsPage({ slug }: DocsPageProps) {
       />
       <Page
         page={{
-          slug,
+          slug: page.slug,
           frontmatter: page.frontmatter,
           content: page.content,
           toc: page.toc

--- a/packages/chronicle/src/server/api/page/index.ts
+++ b/packages/chronicle/src/server/api/page/index.ts
@@ -1,0 +1,1 @@
+export { default } from './[...slug]';


### PR DESCRIPTION
## Summary
- Fix 404 on `/api/page/` during client-side navigation to homepage by adding index route handler that re-exports the catch-all handler
- Sync breadcrumbs with content during navigation by using `page.slug` from context instead of route slug
- Use ApsaraLink for all MDX links (local + external) for consistent styling

## Test plan
- [ ] Click sidebar/navbar links to navigate to homepage — no 404
- [ ] Rename `index.mdx` to `README.md` — homepage still resolves
- [ ] Breadcrumbs and content update together on navigation (no stale breadcrumbs)
- [ ] Local and external links in MDX content have consistent Apsara styling
- [ ] Local links still use client-side navigation (no full page reload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)