### PR TITLE
feat: add .md routes for raw markdown content

### DIFF
--- a/packages/chronicle/src/server/routes/[...slug].md.ts
+++ b/packages/chronicle/src/server/routes/[...slug].md.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs/promises';
+import matter from 'gray-matter';
+import { defineHandler, HTTPError } from 'nitro';
+import { loadConfig } from '@/lib/config';
+import { getPage, getOriginalPath } from '@/lib/source';
+import { safePath } from '@/server/utils/safe-path';
+
+export default defineHandler(async event => {
+  const pathname = event.path || event.req.url?.split('?')[0] || '';
+  if (!pathname.endsWith('.md')) return;
+
+  const config = loadConfig();
+  if (!config.llms?.enabled) {
+    throw new HTTPError({ status: 404, message: 'Not Found' });
+  }
+
+  const stripped = pathname.replace(/\.md$/, '');
+  const parts = stripped === '/index' || stripped === '/'
+    ? []
+    : stripped.slice(1).split('/').filter(Boolean);
+  const page = await getPage(parts);
+
+  if (!page) {
+    throw new HTTPError({ status: 404, message: 'Not Found' });
+  }
+
+  const originalPath = getOriginalPath(page);
+  if (!originalPath) {
+    throw new HTTPError({ status: 404, message: 'Not Found' });
+  }
+
+  const contentDir = __CHRONICLE_CONTENT_DIR__;
+  const filePath = safePath(contentDir, '/' + originalPath);
+  if (!filePath) {
+    throw new HTTPError({ status: 404, message: 'Not Found' });
+  }
+
+  const raw = await fs.readFile(filePath, 'utf-8').catch(() => null);
+  if (!raw) {
+    throw new HTTPError({ status: 404, message: 'Not Found' });
+  }
+
+  event.res.headers.set('Content-Type', 'text/markdown; charset=utf-8');
+  return matter(raw).content;
+});

--- a/packages/chronicle/src/server/routes/llms.txt.ts
+++ b/packages/chronicle/src/server/routes/llms.txt.ts
@@ -12,7 +12,8 @@ export default defineHandler(async event => {
   const pages = await getPages();
   const index = pages.map(p => {
     const fm = extractFrontmatter(p);
-    return `- [${fm.title}](${p.url})`;
+    const mdUrl = p.url === '/' ? '/index.md' : `${p.url}.md`;
+    return `- [${fm.title}](${mdUrl})`;
   }).join('\n');
   const body = `# ${config.title}\n\n${config.description ?? ''}\n\n${index}`;
 


### PR DESCRIPTION
## Summary
- Adds catch-all nitro route (`[...slug].md.ts`) that serves raw markdown at `/*.md` URLs with frontmatter stripped via `gray-matter`
- Gated by `llms.enabled` config — returns 404 when disabled
- Updates `llms.txt` to link `.md` URLs instead of HTML URLs

## Test plan
- [ ] Enable `llms.enabled: true` in `chronicle.yaml`
- [ ] Verify `GET /configuration.md` returns raw markdown without frontmatter
- [ ] Verify `GET /index.md` returns root page markdown
- [ ] Verify `GET /nonexistent.md` returns 404
- [ ] Verify `GET /` still returns HTML
- [ ] Verify `GET /llms.txt` links point to `.md` URLs
- [ ] Verify `.md` routes return 404 when `llms.enabled` is false

🤖 Generated with [Claude Code](https://claude.com/claude-code)