### PR TITLE
refactor: collapse pages API into single handler with query slug

### DIFF
--- a/packages/chronicle/src/lib/page-context.tsx
+++ b/packages/chronicle/src/lib/page-context.tsx
@@ -86,7 +86,7 @@ export function PageProvider({
       ? []
       : pathname.slice(1).split('/').filter(Boolean);
 
-    const apiPath = slug.length === 0 ? '/api/page/' : `/api/page/${slug.join('/')}`;
+    const apiPath = slug.length === 0 ? '/api/page' : `/api/page?slug=${slug.join(',')}`;
 
     fetch(apiPath)
       .then(res => res.json())

--- a/packages/chronicle/src/server/api/page.ts
+++ b/packages/chronicle/src/server/api/page.ts
@@ -2,8 +2,8 @@ import { defineHandler, HTTPError } from 'nitro';
 import { getPage, extractFrontmatter, getRelativePath, getOriginalPath } from '@/lib/source';
 
 export default defineHandler(async event => {
-  const slugParam = event.context.params?.slug ?? '';
-  const slug = slugParam ? slugParam.split('/') : [];
+  const slugParam = event.url.searchParams.get('slug') ?? '';
+  const slug = slugParam ? slugParam.split(',').filter(Boolean) : [];
   const page = await getPage(slug);
 
   if (!page) {

--- a/packages/chronicle/src/server/api/page/index.ts
+++ b/packages/chronicle/src/server/api/page/index.ts
@@ -1,1 +1,0 @@
-export { default } from './[...slug]';


### PR DESCRIPTION
## Summary
- Replace catch-all `/api/page/[...slug]` with single `/api/page` handler
- Slug now passed as comma-separated query param: `?slug=cli,commands`
- Empty/missing slug returns root page

## Test plan
- [ ] `GET /api/page` returns root page (200)
- [ ] `GET /api/page?slug=cli` returns CLI page frontmatter (200)
- [ ] `GET /api/page?slug=nonexistent` returns 404
- [ ] Client navigation still loads pages correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)