### PR TITLE
feat: public dir support, logo and content icon config

### DIFF
--- a/examples/basic/chronicle.yaml
+++ b/examples/basic/chronicle.yaml
@@ -4,12 +4,16 @@ site:
 
 url: https://docs.example.com
 
+logo:
+  light: /logo.svg
+  dark: /logo.svg
+
 content:
   - dir: docs
     label: Docs
 
 theme:
-  name: paper
+  name: default
 
 search:
   enabled: true

--- a/examples/basic/chronicle.yaml
+++ b/examples/basic/chronicle.yaml
@@ -11,6 +11,7 @@ logo:
 content:
   - dir: docs
     label: Docs
+    icon: /icons/docs.svg
 
 theme:
   name: default

--- a/examples/basic/public/icons/docs.svg
+++ b/examples/basic/public/icons/docs.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M2.5 2h8l3 3v9H2.5z"/>
+  <path d="M5 9h6M5 11.5h4"/>
+</svg>

--- a/examples/basic/public/logo.svg
+++ b/examples/basic/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="6" fill="#4F46E5"/>
+  <path d="M8 12h16M8 16h12M8 20h8" stroke="white" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/packages/chronicle/src/server/vite-config.ts
+++ b/packages/chronicle/src/server/vite-config.ts
@@ -48,6 +48,7 @@ export async function createViteConfig(
 
   return {
     root: packageRoot,
+    publicDir: path.resolve(projectRoot, 'public'),
     configFile: false,
     plugins: [
       nitro({
@@ -131,6 +132,7 @@ export async function createViteConfig(
     },
     nitro: {
       logLevel: 2,
+      publicAssets: [{ dir: path.resolve(projectRoot, 'public') }],
       output: {
         dir: resolveOutputDir(projectRoot, preset),
       },


### PR DESCRIPTION
## Summary
- Serve static assets from project's `public/` directory via Vite `publicDir` and Nitro `publicAssets`
- Add logo config to basic example (default theme)
- Add content dir icon support with file-based SVG in `public/icons/`
- Switch basic example to default theme

## Test plan
- [ ] `bun run dev:examples:basic` — logo renders in sidebar header
- [ ] Content icon renders next to "Docs" in sidebar top links
- [ ] Static files from `public/` dir accessible (e.g. `/logo.svg`, `/icons/docs.svg`)
- [ ] Verify production build serves public assets correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)