### PR TITLE
fix: decode URL-encoded characters in SSR pathname

### DIFF
--- a/examples/basic/content/docs/tips-&-tricks.mdx
+++ b/examples/basic/content/docs/tips-&-tricks.mdx
@@ -1,0 +1,9 @@
+---
+title: Tips & Tricks
+description: Useful tips and tricks
+order: 10
+---
+
+# Tips & Tricks
+
+Some helpful tips and tricks for using Chronicle.

--- a/packages/chronicle/src/server/entry-server.tsx
+++ b/packages/chronicle/src/server/entry-server.tsx
@@ -19,7 +19,7 @@ import serverAssets from './entry-server?assets=ssr';
 export default {
   async fetch(req: Request) {
     const url = new URL(req.url);
-    const pathname = url.pathname;
+    const pathname = decodeURIComponent(url.pathname);
 
     const config = loadConfig();
     const route = resolveRoute(pathname, config);


### PR DESCRIPTION
## Summary
- Decode URL-encoded characters (e.g. `%26` → `&`) in SSR pathname before route resolution
- Pages with special characters like `&` in slug previously returned 404
- Add example test file `tips-&-tricks.mdx`

## Test plan
- [x] `/docs/tips-&-tricks` → 200
- [x] `/docs/tips-%26-tricks` → 200
- [x] Normal pages unaffected
- [x] Root redirect still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)