### PR TITLE
feat: support order in meta.json and folder redirect

### DIFF
--- a/packages/chronicle/src/lib/source.ts
+++ b/packages/chronicle/src/lib/source.ts
@@ -118,41 +118,60 @@ export function invalidate() {
   cachedNavMap = null;
 }
 
-function getOrder(node: Node, orderMap: Map<string, number>): number | undefined {
-  if (node.type === 'page') return orderMap.get(node.url);
-  if (node.type === 'folder' && node.index) return orderMap.get(node.index.url);
+function getOrder(node: Node, pageOrderMap: Map<string, number>, folderOrderMap: Map<string, number>): number | undefined {
+  if (node.type === 'page') return pageOrderMap.get(node.url);
+  if (node.type === 'folder') {
+    if (node.index) {
+      const fromMeta = folderOrderMap.get(node.index.url);
+      if (fromMeta !== undefined) return fromMeta;
+      return pageOrderMap.get(node.index.url);
+    }
+  }
   return undefined;
 }
 
-function sortNodes(nodes: Node[], orderMap: Map<string, number>): Node[] {
+function sortNodes(nodes: Node[], pageOrderMap: Map<string, number>, folderOrderMap: Map<string, number>): Node[] {
   return [...nodes]
     .map(n =>
       n.type === 'folder'
-        ? ({ ...n, children: sortNodes(n.children, orderMap) } as Folder)
+        ? ({ ...n, children: sortNodes(n.children, pageOrderMap, folderOrderMap) } as Folder)
         : n
     )
     .sort(
       (a, b) =>
-        (getOrder(a, orderMap) ?? Number.MAX_SAFE_INTEGER) -
-        (getOrder(b, orderMap) ?? Number.MAX_SAFE_INTEGER)
+        (getOrder(a, pageOrderMap, folderOrderMap) ?? Number.MAX_SAFE_INTEGER) -
+        (getOrder(b, pageOrderMap, folderOrderMap) ?? Number.MAX_SAFE_INTEGER)
     );
 }
 
-function sortTreeByOrder(tree: Root, pages: { url: string; data: unknown }[]): Root {
-  const orderMap = new Map<string, number>();
+function buildFolderOrderMap(metaFiles: { path: string; data: Record<string, unknown> }[]): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const meta of metaFiles) {
+    const order = meta.data.order as number | undefined;
+    if (order === undefined) continue;
+    const folderUrl = '/' + meta.path.replace(/\/meta\.json$/, '');
+    map.set(folderUrl, order);
+  }
+  return map;
+}
+
+function sortTreeByOrder(tree: Root, pages: { url: string; data: unknown }[], metaFiles: { path: string; data: Record<string, unknown> }[]): Root {
+  const pageOrderMap = new Map<string, number>();
   for (const page of pages) {
     const d = page.data as Record<string, unknown>;
     const order = d.order as number | undefined;
-    if (order !== undefined) orderMap.set(page.url, order);
-    if (page.url === '/') orderMap.set('/', order ?? 0);
+    if (order !== undefined) pageOrderMap.set(page.url, order);
+    if (page.url === '/') pageOrderMap.set('/', order ?? 0);
   }
-  return { ...tree, children: sortNodes(tree.children, orderMap) };
+  const folderOrderMap = buildFolderOrderMap(metaFiles);
+  return { ...tree, children: sortNodes(tree.children, pageOrderMap, folderOrderMap) };
 }
 
 export async function getPageTree(): Promise<Root> {
   if (cachedTree) return cachedTree;
   const s = await getSource();
-  cachedTree = sortTreeByOrder(s.pageTree as Root, s.getPages());
+  const metaFiles = buildFiles().filter(f => f.type === 'meta') as { path: string; data: Record<string, unknown> }[];
+  cachedTree = sortTreeByOrder(s.pageTree as Root, s.getPages(), metaFiles);
   return cachedTree;
 }
 

--- a/packages/chronicle/src/pages/DocsPage.tsx
+++ b/packages/chronicle/src/pages/DocsPage.tsx
@@ -16,6 +16,18 @@ function getFirstPageUrl(nodes: Node[]): string | null {
   return null;
 }
 
+function findFolderFirstPage(nodes: Node[], pathname: string): string | null {
+  for (const node of nodes) {
+    if (node.type === 'folder') {
+      const folderUrl = node.index?.url;
+      if (folderUrl === pathname) return getFirstPageUrl(node.children);
+      const found = findFolderFirstPage(node.children, pathname);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
 interface DocsPageProps {
   slug: string[];
 }
@@ -24,6 +36,7 @@ export function DocsPage({ slug }: DocsPageProps) {
   const { config, tree, page, isLoading, errorStatus } = usePageContext();
 
   if (errorStatus === 404) {
+    const pathname = `/${slug.join('/')}`;
     const contentConfig = config.content?.find(c => c.dir === slug[0]);
     const isContentRoot = slug.length === 1 && slug[0] === contentConfig?.dir;
     if (contentConfig?.index_page) {
@@ -33,6 +46,8 @@ export function DocsPage({ slug }: DocsPageProps) {
       const firstUrl = getFirstPageUrl(tree.children);
       if (firstUrl) return <Navigate to={firstUrl} replace />;
     }
+    const folderFirstUrl = findFolderFirstPage(tree.children, pathname);
+    if (folderFirstUrl) return <Navigate to={folderFirstUrl} replace />;
     return <NotFound />;
   }
   if (errorStatus) return <NotFound />;

--- a/packages/chronicle/src/pages/DocsPage.tsx
+++ b/packages/chronicle/src/pages/DocsPage.tsx
@@ -24,10 +24,10 @@ export function DocsPage({ slug }: DocsPageProps) {
   const { config, tree, page, isLoading, errorStatus } = usePageContext();
 
   if (errorStatus === 404) {
-    const isContentRoot = config.content?.some(c => slug.length === 1 && slug[0] === c.dir);
-    const contentEntry = config.content?.find(c => slug.length === 1 && slug[0] === c.dir);
-    if (contentEntry?.index_page) {
-      return <Navigate to={`/${contentEntry.dir}/${contentEntry.index_page}`} replace />;
+    const contentConfig = config.content?.find(c => c.dir === slug[0]);
+    const isContentRoot = slug.length === 1 && slug[0] === contentConfig?.dir;
+    if (contentConfig?.index_page) {
+      return <Navigate to={`/${contentConfig.dir}/${contentConfig.index_page}`} replace />;
     }
     if (isContentRoot) {
       const firstUrl = getFirstPageUrl(tree.children);

--- a/packages/chronicle/src/pages/DocsPage.tsx
+++ b/packages/chronicle/src/pages/DocsPage.tsx
@@ -24,7 +24,11 @@ export function DocsPage({ slug }: DocsPageProps) {
   const { config, tree, page, isLoading, errorStatus } = usePageContext();
 
   if (errorStatus === 404) {
-    const isContentRoot = config.content?.some(c => slug.length === 1 && slug[0] === c.dir);
+    const contentEntry = config.content?.find(c => slug.length === 1 && slug[0] === c.dir);
+    const isContentRoot = !!contentEntry;
+    if (contentEntry?.index_page) {
+      return <Navigate to={`/${contentEntry.dir}/${contentEntry.index_page}`} replace />;
+    }
     if (isContentRoot) {
       const firstUrl = getFirstPageUrl(tree.children);
       if (firstUrl) return <Navigate to={firstUrl} replace />;

--- a/packages/chronicle/src/pages/DocsPage.tsx
+++ b/packages/chronicle/src/pages/DocsPage.tsx
@@ -24,8 +24,8 @@ export function DocsPage({ slug }: DocsPageProps) {
   const { config, tree, page, isLoading, errorStatus } = usePageContext();
 
   if (errorStatus === 404) {
+    const isContentRoot = config.content?.some(c => slug.length === 1 && slug[0] === c.dir);
     const contentEntry = config.content?.find(c => slug.length === 1 && slug[0] === c.dir);
-    const isContentRoot = !!contentEntry;
     if (contentEntry?.index_page) {
       return <Navigate to={`/${contentEntry.dir}/${contentEntry.index_page}`} replace />;
     }

--- a/packages/chronicle/src/types/config.ts
+++ b/packages/chronicle/src/types/config.ts
@@ -86,6 +86,7 @@ const contentEntrySchema = z.object({
   label: z.string().min(1),
   description: z.string().optional(),
   icon: z.string().optional(),
+  index_page: z.string().optional(),
 })
 
 // Variants map to Apsara Badge color prop.


### PR DESCRIPTION
## Summary

- Add `order` field to `meta.json` for sorting folders in sidebar
- Lower order = appears first, no order = end of list
- Folder order from meta.json takes priority over index page frontmatter order
- Visiting a folder URL (e.g., `/docs/guides`) redirects to its first sorted child page

### Usage

```json
// docs/getting-started/meta.json
{
  "title": "Getting Started",
  "order": 1
}

// docs/guides/meta.json
{
  "title": "Guides",
  "order": 2
}
```

## Test plan

- [ ] Add `order` to `meta.json` files — sidebar respects order
- [ ] Folder without `order` appears after ordered folders
- [ ] Visit folder URL without index page — redirects to first child
- [ ] Existing page `order` frontmatter still works
- [ ] Breadcrumbs show `title` from `meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)