### PR TITLE
feat: full-text search with SQLite FTS5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,7 +44,6 @@
         "h3": "^2.0.1-rc.16",
         "lodash": "^4.17.23",
         "mermaid": "^11.13.0",
-        "minisearch": "^7.2.0",
         "nitro": "3.0.260311-beta",
         "openapi-types": "^12.1.3",
         "react": "^19.0.0",
@@ -868,8 +867,6 @@
     "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
-
-    "minisearch": ["minisearch@7.2.0", "", {}, "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg=="],
 
     "mlly": ["mlly@1.8.1", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ=="],
 

--- a/examples/basic/content/docs/guides/deployment.mdx
+++ b/examples/basic/content/docs/guides/deployment.mdx
@@ -1,0 +1,187 @@
+---
+title: Deployment
+description: Deploy Chronicle to production
+order: 3
+---
+
+# Deployment
+
+Chronicle builds to a standalone Node.js server that can be deployed anywhere.
+
+## Build
+
+```bash
+bunx chronicle build
+```
+
+This outputs a production build to `.output/`.
+
+## Start
+
+```bash
+bunx chronicle start
+```
+
+Starts the production server on port 3000.
+
+## Environment Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `PORT` | Server port | `3000` |
+| `HOST` | Server host | `0.0.0.0` |
+
+## Docker
+
+```dockerfile
+FROM oven/bun:latest AS builder
+WORKDIR /app
+COPY . .
+RUN bun install
+RUN bunx chronicle build
+
+FROM node:20-slim
+WORKDIR /app
+COPY --from=builder /app/.output .output
+EXPOSE 3000
+CMD ["node", ".output/server/index.mjs"]
+```
+
+Build and run:
+
+```bash
+docker build -t my-docs .
+docker run -p 3000:3000 my-docs
+```
+
+## Docker Compose
+
+```yaml
+version: '3.8'
+services:
+  docs:
+    build: .
+    ports:
+      - '3000:3000'
+    restart: unless-stopped
+```
+
+## Kubernetes
+
+### Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chronicle-docs
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: chronicle-docs
+  template:
+    metadata:
+      labels:
+        app: chronicle-docs
+    spec:
+      containers:
+        - name: docs
+          image: my-docs:latest
+          ports:
+            - containerPort: 3000
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /api/ready
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+```
+
+### Service
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chronicle-docs
+spec:
+  selector:
+    app: chronicle-docs
+  ports:
+    - port: 80
+      targetPort: 3000
+  type: ClusterIP
+```
+
+### Ingress
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: chronicle-docs
+spec:
+  rules:
+    - host: docs.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: chronicle-docs
+                port:
+                  number: 80
+```
+
+### Health Endpoints
+
+| Endpoint | Purpose | Response |
+|---|---|---|
+| `GET /api/health` | Liveness probe | `200 {"status":"ok"}` always |
+| `GET /api/ready` | Readiness probe | `200 {"status":"ready"}` when search index built, `503` otherwise |
+
+The readiness probe returns `503` until the search FTS index is built. On pod restart or redeploy, the index rebuilds automatically on first request. Kubernetes will not route traffic to the pod until it reports ready.
+
+## Vercel
+
+Add `vercel.json`:
+
+```json
+{
+  "buildCommand": "bunx chronicle build",
+  "outputDirectory": ".output/public",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/api/server" }
+  ]
+}
+```
+
+## Netlify
+
+Add `netlify.toml`:
+
+```toml
+[build]
+  command = "bunx chronicle build"
+  publish = ".output/public"
+
+[[redirects]]
+  from = "/*"
+  to = "/.netlify/functions/server"
+  status = 200
+```

--- a/packages/chronicle/package.json
+++ b/packages/chronicle/package.json
@@ -61,7 +61,6 @@
     "h3": "^2.0.1-rc.16",
     "lodash": "^4.17.23",
     "mermaid": "^11.13.0",
-    "minisearch": "^7.2.0",
     "nitro": "3.0.260311-beta",
     "openapi-types": "^12.1.3",
     "react": "^19.0.0",

--- a/packages/chronicle/src/components/ui/search.module.css
+++ b/packages/chronicle/src/components/ui/search.module.css
@@ -13,6 +13,7 @@
 
 .list {
   max-height: 400px;
+  gap: var(--rs-space-3);
 }
 
 .list :global([cmdk-group-heading]) {
@@ -24,12 +25,13 @@
 }
 
 .item {
-  height: 32px;
+  min-height: 40px;
   padding: var(--rs-space-3);
   gap: var(--rs-space-3);
   border-radius: var(--rs-radius-2);
   cursor: pointer;
 }
+
 
 .item[data-selected="true"] {
   background: var(--rs-color-background-base-primary-hover);
@@ -43,8 +45,9 @@
 
 .resultText {
   display: flex;
-  align-items: center;
-  gap: 8px;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
 }
 
 .headingText {
@@ -68,14 +71,33 @@
 }
 
 .icon {
-  width: 18px;
-  height: 18px;
+  width: 48px;
+  height: 24px;
   color: var(--rs-color-foreground-base-secondary);
   flex-shrink: 0;
 }
 
+.itemContent :global([class*="badge-module"]) {
+  min-width: 48px;
+  justify-content: center;
+}
+
 .item[data-selected="true"] .icon {
   color: var(--rs-color-foreground-accent-primary-hover);
+}
+
+.snippetText {
+  font-size: var(--rs-font-size-mini);
+  line-height: var(--rs-line-height-mini);
+  color: var(--rs-color-foreground-base-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.matchHighlight {
+  color: var(--rs-color-foreground-accent-primary);
+  font-weight: var(--rs-font-weight-medium);
 }
 
 .pageText :global(mark),

--- a/packages/chronicle/src/components/ui/search.tsx
+++ b/packages/chronicle/src/components/ui/search.tsx
@@ -16,6 +16,8 @@ interface SearchResult {
   url: string;
   type: string;
   content: string;
+  match?: 'title' | 'heading' | 'body';
+  snippet?: string;
 }
 
 interface SearchProps {
@@ -121,7 +123,7 @@ export function Search({ classNames }: SearchProps) {
 
       <Command.Dialog open={open} onOpenChange={setOpen}>
         <Command.DialogContent className={styles.dialogContent}>
-          <Command>
+          <Command items={displayResults}>
             <Command.Input
               placeholder='Search'
               leadingIcon={<MagnifyingGlassIcon width={16} height={16} />}
@@ -171,23 +173,17 @@ export function Search({ classNames }: SearchProps) {
                     <div className={styles.itemContent}>
                       {getResultIcon(result)}
                       <div className={styles.resultText}>
-                        {result.type === 'heading' ? (
-                          <>
-                            <Text className={styles.headingText}>
-                              <HighlightedText
-                                html={stripMethod(result.content)}
-                              />
-                            </Text>
-                            <Text className={styles.separator}>-</Text>
-                            <Text className={styles.pageText}>
-                              {getPageTitle(result.url)}
-                            </Text>
-                          </>
-                        ) : (
-                          <Text className={styles.pageText}>
-                            <HighlightedText
-                              html={stripMethod(result.content)}
-                            />
+                        <Text className={styles.pageText}>
+                          <HighlightQuery text={stripMethod(result.content)} query={search} />
+                        </Text>
+                        {result.snippet && result.match === 'heading' && (
+                          <Text className={styles.snippetText}>
+                            # <HighlightQuery text={result.snippet} query={search} />
+                          </Text>
+                        )}
+                        {result.snippet && result.match === 'body' && (
+                          <Text className={styles.snippetText}>
+                            <HighlightQuery text={result.snippet} query={search} />
                           </Text>
                         )}
                       </div>
@@ -233,6 +229,19 @@ function HighlightedText({
 }) {
   return (
     <span className={className} dangerouslySetInnerHTML={{ __html: html }} />
+  );
+}
+
+function HighlightQuery({ text, query }: { text: string; query: string }) {
+  if (!query) return <>{text}</>;
+  const idx = text.toLowerCase().indexOf(query.toLowerCase());
+  if (idx < 0) return <>{text}</>;
+  return (
+    <>
+      {text.slice(0, idx)}
+      <span className={styles.matchHighlight}>{text.slice(idx, idx + query.length)}</span>
+      {text.slice(idx + query.length)}
+    </>
   );
 }
 

--- a/packages/chronicle/src/lib/source.ts
+++ b/packages/chronicle/src/lib/source.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import { loader } from 'fumadocs-core/source';
 import { flattenTree } from 'fumadocs-core/page-tree';
 import type { Root, Node, Folder } from 'fumadocs-core/page-tree';
@@ -238,6 +240,35 @@ export function getRelativePath(page: { data: unknown }): string {
 
 export function getOriginalPath(page: { data: unknown }): string {
   return ((page.data as Record<string, unknown>)._originalPath as string) ?? '';
+}
+
+export async function getPageSearchContent(page: { data: unknown }): Promise<{ headings: string; body: string }> {
+  const originalPath = getOriginalPath(page);
+  if (!originalPath) return { headings: '', body: '' };
+  try {
+    const contentDir = typeof __CHRONICLE_CONTENT_DIR__ !== 'undefined' ? __CHRONICLE_CONTENT_DIR__ : process.cwd();
+    const filePath = path.resolve(contentDir, originalPath);
+    const raw = await fs.readFile(filePath, 'utf-8');
+    const withoutFrontmatter = raw.replace(/^---[\s\S]*?---/m, '');
+    const headings: string[] = [];
+    const lines: string[] = [];
+    for (const line of withoutFrontmatter.split('\n')) {
+      const headingMatch = line.match(/^#{1,6}\s+(.+)/);
+      if (headingMatch) {
+        headings.push(headingMatch[1]);
+      } else if (!line.startsWith('import ') && !line.startsWith('export ') && !line.startsWith('```')) {
+        const cleaned = line
+          .replace(/<[^>]+>/g, '')
+          .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+          .replace(/[*_~`]+/g, '')
+          .trim();
+        if (cleaned) lines.push(cleaned);
+      }
+    }
+    return { headings: headings.join(' '), body: lines.join(' ') };
+  } catch {
+    return { headings: '', body: '' };
+  }
 }
 
 interface ReadingTime {

--- a/packages/chronicle/src/lib/source.ts
+++ b/packages/chronicle/src/lib/source.ts
@@ -265,7 +265,7 @@ export async function getPageSearchContent(page: { data: unknown }): Promise<{ h
         if (cleaned) lines.push(cleaned);
       }
     }
-    return { headings: headings.join(' '), body: lines.join(' ') };
+    return { headings: headings.join('\n'), body: lines.join(' ') };
   } catch {
     return { headings: '', body: '' };
   }

--- a/packages/chronicle/src/server/api/ready.ts
+++ b/packages/chronicle/src/server/api/ready.ts
@@ -1,0 +1,15 @@
+import { defineHandler } from 'nitro';
+import { isSearchReady } from './search';
+
+export default defineHandler(() => {
+  const searchReady = isSearchReady();
+
+  if (!searchReady) {
+    return Response.json(
+      { status: 'not_ready', search: false },
+      { status: 503 },
+    );
+  }
+
+  return Response.json({ status: 'ready', search: true });
+});

--- a/packages/chronicle/src/server/api/search.ts
+++ b/packages/chronicle/src/server/api/search.ts
@@ -1,7 +1,7 @@
-import MiniSearch from 'minisearch';
 import { defineHandler, HTTPError } from 'nitro';
+import { useDatabase } from 'nitro/database';
 import type { OpenAPIV3 } from 'openapi-types';
-import { getSpecSlug } from '@/lib/api-routes';
+import { getSpecSlug, getFirstApiUrl } from '@/lib/api-routes';
 import { getApiConfigsForVersion, loadConfig } from '@/lib/config';
 import { loadApiSpecs } from '@/lib/openapi';
 import { extractFrontmatter, getPagesForVersion } from '@/lib/source';
@@ -15,93 +15,91 @@ interface SearchDocument {
   type: 'page' | 'api';
 }
 
-const indexCache = new Map<string, MiniSearch<SearchDocument>>();
-const docsCache = new Map<string, SearchDocument[]>();
+const indexedVersions = new Set<string>();
 
-function keyFor(ctx: VersionContext): string {
+function versionKey(ctx: VersionContext): string {
   return ctx.dir ?? '__latest__';
 }
 
-function createIndex(docs: SearchDocument[]): MiniSearch<SearchDocument> {
-  const index = new MiniSearch<SearchDocument>({
-    fields: ['title', 'content'],
-    storeFields: ['url', 'title', 'type'],
-    searchOptions: {
-      boost: { title: 2 },
-      fuzzy: 0.2,
-      prefix: true
-    }
-  });
-  index.addAll(docs);
-  return index;
+async function ensureIndex(ctx: VersionContext) {
+  const key = versionKey(ctx);
+  if (indexedVersions.has(key)) return;
+
+  const db = useDatabase();
+
+  await db.sql`DROP TABLE IF EXISTS search_docs`;
+  await db.sql`DROP TABLE IF EXISTS search_fts`;
+
+  await db.sql`CREATE TABLE IF NOT EXISTS search_docs (
+    id TEXT PRIMARY KEY,
+    url TEXT NOT NULL,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    type TEXT NOT NULL,
+    version TEXT NOT NULL
+  )`;
+
+  await db.sql`CREATE VIRTUAL TABLE IF NOT EXISTS search_fts USING fts5(
+    title,
+    content,
+    content=search_docs,
+    content_rowid=rowid
+  )`;
+
+  const docs = await buildDocs(ctx);
+  for (const doc of docs) {
+    await db.sql`INSERT INTO search_docs (id, url, title, content, type, version)
+      VALUES (${doc.id}, ${doc.url}, ${doc.title}, ${doc.content}, ${doc.type}, ${key})`;
+  }
+
+  await db.sql`INSERT INTO search_fts (rowid, title, content)
+    SELECT rowid, title, content FROM search_docs WHERE version = ${key}`;
+
+  indexedVersions.add(key);
 }
 
-async function scanContent(ctx: VersionContext): Promise<SearchDocument[]> {
+async function buildDocs(ctx: VersionContext): Promise<SearchDocument[]> {
+  const docs: SearchDocument[] = [];
+
   const pages = await getPagesForVersion(ctx);
-  return pages.map(p => {
+  for (const p of pages) {
     const fm = extractFrontmatter(p);
-    return {
+    docs.push({
       id: p.url,
       url: p.url,
       title: fm.title,
-      content: fm.description ?? '',
-      type: 'page' as const
-    };
-  });
-}
+      content: [fm.title, fm.description ?? ''].join(' '),
+      type: 'page',
+    });
+  }
 
-async function buildApiDocs(ctx: VersionContext): Promise<SearchDocument[]> {
   const config = loadConfig();
   const apiConfigs = getApiConfigsForVersion(config, ctx.dir);
-  if (!apiConfigs.length) return [];
-
-  const docs: SearchDocument[] = [];
-  const specs = await loadApiSpecs(apiConfigs);
-
-  for (const spec of specs) {
-    const specSlug = getSpecSlug(spec);
-    const paths = spec.document.paths ?? {};
-    for (const [, pathItem] of Object.entries(paths)) {
-      if (!pathItem) continue;
-      for (const method of ['get', 'post', 'put', 'delete', 'patch'] as const) {
-        const op = pathItem[method] as OpenAPIV3.OperationObject | undefined;
-        if (!op?.operationId) continue;
-        const url = `${ctx.urlPrefix}/apis/${specSlug}/${encodeURIComponent(op.operationId)}`;
-        docs.push({
-          id: url,
-          url,
-          title: `${method.toUpperCase()} ${op.summary ?? op.operationId}`,
-          content: op.description ?? '',
-          type: 'api'
-        });
+  if (apiConfigs.length) {
+    const specs = await loadApiSpecs(apiConfigs);
+    for (const spec of specs) {
+      const specSlug = getSpecSlug(spec);
+      const paths = spec.document.paths ?? {};
+      for (const [pathStr, pathItem] of Object.entries(paths)) {
+        if (!pathItem) continue;
+        for (const method of ['get', 'post', 'put', 'delete', 'patch'] as const) {
+          const op = pathItem[method] as OpenAPIV3.OperationObject | undefined;
+          if (!op) continue;
+          const opId = op.operationId ?? `${method}_${pathStr.replace(/[/{}\-]/g, '_').replace(/_+/g, '_').replace(/^_|_$/g, '')}`;
+          const url = `${ctx.urlPrefix}/apis/${specSlug}/${encodeURIComponent(opId)}`;
+          docs.push({
+            id: url,
+            url,
+            title: `${method.toUpperCase()} ${op.summary ?? opId}`,
+            content: [op.summary ?? '', op.description ?? '', pathStr, method.toUpperCase()].join(' '),
+            type: 'api',
+          });
+        }
       }
     }
   }
 
   return docs;
-}
-
-async function getDocs(ctx: VersionContext): Promise<SearchDocument[]> {
-  const key = keyFor(ctx);
-  const cached = docsCache.get(key);
-  if (cached) return cached;
-  const [contentDocs, apiDocs] = await Promise.all([
-    scanContent(ctx),
-    buildApiDocs(ctx)
-  ]);
-  const docs = [...contentDocs, ...apiDocs];
-  docsCache.set(key, docs);
-  return docs;
-}
-
-async function getIndex(ctx: VersionContext): Promise<MiniSearch<SearchDocument>> {
-  const key = keyFor(ctx);
-  const cached = indexCache.get(key);
-  if (cached) return cached;
-  const docs = await getDocs(ctx);
-  const index = createIndex(docs);
-  indexCache.set(key, index);
-  return index;
 }
 
 function resolveCtx(tag: string | null): VersionContext {
@@ -121,25 +119,37 @@ export default defineHandler(async event => {
   const query = event.url.searchParams.get('query') ?? '';
   const tag = event.url.searchParams.get('tag');
   const ctx = resolveCtx(tag);
-  const index = await getIndex(ctx);
+
+  await ensureIndex(ctx);
+  const db = useDatabase();
+  const key = versionKey(ctx);
 
   if (!query) {
-    const docs = await getDocs(ctx);
-    return Response.json(docs
-      .filter(d => d.type === 'page')
-      .slice(0, 8)
-      .map(d => ({
-        id: d.id,
-        url: d.url,
-        type: d.type,
-        content: d.title
-      })));
+    const result = await db.sql`SELECT id, url, title, type FROM search_docs
+      WHERE version = ${key} AND type = 'page'
+      LIMIT 8`;
+    return Response.json((result.rows ?? []).map(r => ({
+      id: r.id,
+      url: r.url,
+      type: r.type,
+      content: r.title,
+    })));
   }
 
-  return Response.json(index.search(query).map(r => ({
+  const searchTerm = query.split(/\s+/).map(t => `"${t}"*`).join(' ');
+  const result = await db.sql`SELECT s.id, s.url, s.title, s.type,
+      rank
+    FROM search_fts f
+    JOIN search_docs s ON s.rowid = f.rowid
+    WHERE search_fts MATCH ${searchTerm}
+      AND s.version = ${key}
+    ORDER BY rank
+    LIMIT 20`;
+
+  return Response.json((result.rows ?? []).map(r => ({
     id: r.id,
     url: r.url,
     type: r.type,
-    content: r.title
+    content: r.title,
   })));
 });

--- a/packages/chronicle/src/server/api/search.ts
+++ b/packages/chronicle/src/server/api/search.ts
@@ -4,14 +4,15 @@ import type { OpenAPIV3 } from 'openapi-types';
 import { getSpecSlug, getFirstApiUrl } from '@/lib/api-routes';
 import { getApiConfigsForVersion, loadConfig } from '@/lib/config';
 import { loadApiSpecs } from '@/lib/openapi';
-import { extractFrontmatter, getPagesForVersion } from '@/lib/source';
+import { extractFrontmatter, getPageSearchContent, getPagesForVersion } from '@/lib/source';
 import { LATEST_CONTEXT, type VersionContext } from '@/lib/version-source';
 
 interface SearchDocument {
   id: string;
   url: string;
   title: string;
-  content: string;
+  headings: string;
+  body: string;
   type: 'page' | 'api';
 }
 
@@ -34,26 +35,28 @@ async function ensureIndex(ctx: VersionContext) {
     id TEXT PRIMARY KEY,
     url TEXT NOT NULL,
     title TEXT NOT NULL,
-    content TEXT NOT NULL,
+    headings TEXT NOT NULL,
+    body TEXT NOT NULL,
     type TEXT NOT NULL,
     version TEXT NOT NULL
   )`;
 
   await db.sql`CREATE VIRTUAL TABLE IF NOT EXISTS search_fts USING fts5(
     title,
-    content,
+    headings,
+    body,
     content=search_docs,
     content_rowid=rowid
   )`;
 
   const docs = await buildDocs(ctx);
   for (const doc of docs) {
-    await db.sql`INSERT INTO search_docs (id, url, title, content, type, version)
-      VALUES (${doc.id}, ${doc.url}, ${doc.title}, ${doc.content}, ${doc.type}, ${key})`;
+    await db.sql`INSERT INTO search_docs (id, url, title, headings, body, type, version)
+      VALUES (${doc.id}, ${doc.url}, ${doc.title}, ${doc.headings}, ${doc.body}, ${doc.type}, ${key})`;
   }
 
-  await db.sql`INSERT INTO search_fts (rowid, title, content)
-    SELECT rowid, title, content FROM search_docs WHERE version = ${key}`;
+  await db.sql`INSERT INTO search_fts (rowid, title, headings, body)
+    SELECT rowid, title, headings, body FROM search_docs WHERE version = ${key}`;
 
   indexedVersions.add(key);
 }
@@ -64,11 +67,13 @@ async function buildDocs(ctx: VersionContext): Promise<SearchDocument[]> {
   const pages = await getPagesForVersion(ctx);
   for (const p of pages) {
     const fm = extractFrontmatter(p);
+    const { headings, body } = await getPageSearchContent(p);
     docs.push({
       id: p.url,
       url: p.url,
       title: fm.title,
-      content: [fm.title, fm.description ?? ''].join(' '),
+      headings,
+      body: [fm.description ?? '', body].join(' '),
       type: 'page',
     });
   }
@@ -91,7 +96,8 @@ async function buildDocs(ctx: VersionContext): Promise<SearchDocument[]> {
             id: url,
             url,
             title: `${method.toUpperCase()} ${op.summary ?? opId}`,
-            content: [op.summary ?? '', op.description ?? '', pathStr, method.toUpperCase()].join(' '),
+            headings: op.summary ?? opId,
+            body: [op.description ?? '', pathStr, method.toUpperCase()].join(' '),
             type: 'api',
           });
         }
@@ -138,12 +144,12 @@ export default defineHandler(async event => {
 
   const searchTerm = query.split(/\s+/).map(t => `"${t}"*`).join(' ');
   const result = await db.sql`SELECT s.id, s.url, s.title, s.type,
-      rank
+      bm25(search_fts, 10.0, 5.0, 1.0) AS score
     FROM search_fts f
     JOIN search_docs s ON s.rowid = f.rowid
     WHERE search_fts MATCH ${searchTerm}
       AND s.version = ${key}
-    ORDER BY rank
+    ORDER BY score
     LIMIT 20`;
 
   return Response.json((result.rows ?? []).map(r => ({

--- a/packages/chronicle/src/server/api/search.ts
+++ b/packages/chronicle/src/server/api/search.ts
@@ -1,7 +1,7 @@
 import { defineHandler, HTTPError } from 'nitro';
 import { useDatabase } from 'nitro/database';
 import type { OpenAPIV3 } from 'openapi-types';
-import { getSpecSlug, getFirstApiUrl } from '@/lib/api-routes';
+import { getSpecSlug } from '@/lib/api-routes';
 import { getApiConfigsForVersion, loadConfig } from '@/lib/config';
 import { loadApiSpecs } from '@/lib/openapi';
 import { extractFrontmatter, getPageSearchContent, getPagesForVersion } from '@/lib/source';
@@ -30,6 +30,7 @@ function versionKey(ctx: VersionContext): string {
   return ctx.dir ?? '__latest__';
 }
 
+// biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op catch
 fs.unlink(LOCK_FILE).catch(() => {});
 
 export function isSearchReady(): boolean {
@@ -47,6 +48,7 @@ export async function ensureIndex(ctx: VersionContext) {
 }
 
 async function buildIndex(ctx: VersionContext, key: string) {
+  // biome-ignore lint/correctness/useHookAtTopLevel: useDatabase is a Nitro DI accessor, not a React hook
   const db = useDatabase();
 
   await db.exec('DROP TABLE IF EXISTS search_fts');
@@ -176,6 +178,7 @@ export default defineHandler(async event => {
   const ctx = resolveCtx(tag);
 
   await ensureIndex(ctx);
+  // biome-ignore lint/correctness/useHookAtTopLevel: useDatabase is a Nitro DI accessor, not a React hook
   const db = useDatabase();
   const key = versionKey(ctx);
 

--- a/packages/chronicle/src/server/api/search.ts
+++ b/packages/chronicle/src/server/api/search.ts
@@ -16,22 +16,43 @@ interface SearchDocument {
   type: 'page' | 'api';
 }
 
-const indexedVersions = new Set<string>();
+import fs from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const LOCK_FILE = path.join(os.tmpdir(), 'chronicle-search-ready');
+
+export const indexedVersions = new Set<string>();
+let indexPromise: Promise<void> | null = null;
 
 function versionKey(ctx: VersionContext): string {
   return ctx.dir ?? '__latest__';
 }
 
-async function ensureIndex(ctx: VersionContext) {
+fs.unlink(LOCK_FILE).catch(() => {});
+
+export function isSearchReady(): boolean {
+  return existsSync(LOCK_FILE);
+}
+
+export async function ensureIndex(ctx: VersionContext) {
   const key = versionKey(ctx);
   if (indexedVersions.has(key)) return;
+  if (indexPromise) return indexPromise;
+  indexPromise = buildIndex(ctx, key);
+  await indexPromise;
+  indexPromise = null;
+  await fs.writeFile(LOCK_FILE, new Date().toISOString());
+}
 
+async function buildIndex(ctx: VersionContext, key: string) {
   const db = useDatabase();
 
-  await db.sql`DROP TABLE IF EXISTS search_docs`;
-  await db.sql`DROP TABLE IF EXISTS search_fts`;
+  await db.exec('DROP TABLE IF EXISTS search_fts');
+  await db.exec('DROP TABLE IF EXISTS search_docs');
 
-  await db.sql`CREATE TABLE IF NOT EXISTS search_docs (
+  await db.exec(`CREATE TABLE IF NOT EXISTS search_docs (
     id TEXT PRIMARY KEY,
     url TEXT NOT NULL,
     title TEXT NOT NULL,
@@ -39,15 +60,15 @@ async function ensureIndex(ctx: VersionContext) {
     body TEXT NOT NULL,
     type TEXT NOT NULL,
     version TEXT NOT NULL
-  )`;
+  )`);
 
-  await db.sql`CREATE VIRTUAL TABLE IF NOT EXISTS search_fts USING fts5(
+  await db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS search_fts USING fts5(
     title,
     headings,
     body,
     content=search_docs,
     content_rowid=rowid
-  )`;
+  )`);
 
   const docs = await buildDocs(ctx);
   for (const doc of docs) {
@@ -187,7 +208,7 @@ export default defineHandler(async event => {
       id: r.id,
       url: r.url,
       type: r.type,
-      title: r.title,
+      content: r.title,
       match,
       snippet,
     };

--- a/packages/chronicle/src/server/api/search.ts
+++ b/packages/chronicle/src/server/api/search.ts
@@ -108,6 +108,34 @@ async function buildDocs(ctx: VersionContext): Promise<SearchDocument[]> {
   return docs;
 }
 
+function findMatch(
+  query: string,
+  title: string,
+  headings: string,
+  body: string,
+): { match: 'title' | 'heading' | 'body'; snippet: string } {
+  if (title.toLowerCase().includes(query)) {
+    return { match: 'title', snippet: title };
+  }
+
+  const headingList = headings.split('\n').filter(Boolean);
+  for (const h of headingList) {
+    if (h.toLowerCase().includes(query)) {
+      return { match: 'heading', snippet: h };
+    }
+  }
+
+  const idx = body.toLowerCase().indexOf(query);
+  if (idx >= 0) {
+    const start = Math.max(0, idx - 40);
+    const end = Math.min(body.length, idx + query.length + 80);
+    const snippet = (start > 0 ? '...' : '') + body.slice(start, end).trim() + (end < body.length ? '...' : '');
+    return { match: 'body', snippet };
+  }
+
+  return { match: 'title', snippet: title };
+}
+
 function resolveCtx(tag: string | null): VersionContext {
   if (!tag) return LATEST_CONTEXT;
   const config = loadConfig();
@@ -143,7 +171,7 @@ export default defineHandler(async event => {
   }
 
   const searchTerm = query.split(/\s+/).map(t => `"${t}"*`).join(' ');
-  const result = await db.sql`SELECT s.id, s.url, s.title, s.type,
+  const result = await db.sql`SELECT s.id, s.url, s.title, s.headings, s.body, s.type,
       bm25(search_fts, 10.0, 5.0, 1.0) AS score
     FROM search_fts f
     JOIN search_docs s ON s.rowid = f.rowid
@@ -152,10 +180,16 @@ export default defineHandler(async event => {
     ORDER BY score
     LIMIT 20`;
 
-  return Response.json((result.rows ?? []).map(r => ({
-    id: r.id,
-    url: r.url,
-    type: r.type,
-    content: r.title,
-  })));
+  const queryLower = query.toLowerCase();
+  return Response.json((result.rows ?? []).map(r => {
+    const { match, snippet } = findMatch(queryLower, r.title as string, r.headings as string, r.body as string);
+    return {
+      id: r.id,
+      url: r.url,
+      type: r.type,
+      title: r.title,
+      match,
+      snippet,
+    };
+  }));
 });

--- a/packages/chronicle/src/server/vite-config.ts
+++ b/packages/chronicle/src/server/vite-config.ts
@@ -136,6 +136,15 @@ export async function createViteConfig(
       output: {
         dir: resolveOutputDir(projectRoot, preset),
       },
+      experimental: {
+        database: true,
+      },
+      database: {
+        default: {
+          connector: 'sqlite',
+          options: { name: 'chronicle-search' },
+        },
+      },
     },
   };
 }


### PR DESCRIPTION
## Summary

Replace MiniSearch with SQLite FTS5 via Nitro database for full-text search across docs and API pages.

### Commits

1. **Enable Nitro SQLite database** — configure experimental database with SQLite connector
2. **Replace MiniSearch with FTS5** — FTS5 virtual table, ranked search, fresh index per deploy
3. **Remove minisearch dependency**
4. **Index page body content and headings** — read raw MDX files, extract headings + body text, separate FTS columns with bm25 ranking (title 10x, headings 5x, body 1x)
5. **Match type and snippets** — results include match field (title/heading/body) with contextual snippet
6. **Readiness endpoint + UI** — `/api/ready` returns 503 until index built, search UI shows highlighted snippets with `#` prefix for headings

### Search features

- Full-text search across page titles, headings, and body content
- API endpoint search (summary, description, path, method)
- bm25 ranking: title matches > heading matches > body matches
- Snippet extraction with match highlighting in accent color
- Readiness probe (`/api/ready`) for k8s — lock file in /tmp, deleted on restart
- Race condition protection with index mutex
- Client-side filtering disabled (server-side FTS handles it)

## Test plan

- [ ] Search for a word in page title — shows as title match
- [ ] Search for a heading — shows with `#` prefix snippet
- [ ] Search for body text — shows contextual snippet with highlight
- [ ] Search for API operation — finds by summary/description
- [ ] `/api/ready` returns 503 before first search, 200 after
- [ ] Restart server — `/api/ready` returns 503 again until re-indexed
- [ ] Search UI renders results with snippets and highlights

🤖 Generated with [Claude Code](https://claude.com/claude-code)