### PR TITLE
feat: render frontmatter title in default theme

### DIFF
--- a/packages/chronicle/src/themes/default/Page.module.css
+++ b/packages/chronicle/src/themes/default/Page.module.css
@@ -11,6 +11,10 @@
   max-width: 768px;
 }
 
+.title {
+  margin: 0 0 var(--rs-space-8) 0;
+}
+
 .content {
   line-height: 1.7;
 }

--- a/packages/chronicle/src/themes/default/Page.tsx
+++ b/packages/chronicle/src/themes/default/Page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Flex } from '@raystack/apsara';
+import { Flex, Headline } from '@raystack/apsara';
 import type { ThemePageProps } from '@/types';
 import styles from './Page.module.css';
 import { Toc } from './Toc';
@@ -9,6 +9,11 @@ export function Page({ page }: ThemePageProps) {
   return (
     <Flex className={styles.page}>
       <article className={styles.article} data-article-content>
+        {page.frontmatter.title && (
+          <Headline size="t2" render={<h1 />} className={styles.title}>
+            {page.frontmatter.title}
+          </Headline>
+        )}
         <div className={styles.content}>{page.content}</div>
       </article>
       <Toc items={page.toc} />


### PR DESCRIPTION
## Summary

- Render frontmatter `title` as h1 above page content in default theme
- Users should remove `# Title` from MDX body to avoid duplicate headings

## Test plan

- [ ] Page with frontmatter title + no h1 in body → title shows
- [ ] Page with frontmatter title + h1 in body → both show (user removes h1)
- [ ] Page without frontmatter title → no extra heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)