### PR TITLE
fix: meta.json order sorting for folders without index pages

### DIFF
--- a/examples/basic/content/docs/features.mdx
+++ b/examples/basic/content/docs/features.mdx
@@ -128,6 +128,72 @@ lastModified: 2024-01-15
 
 ---
 
+## Sorting Pages and Folders
+
+Control the order of pages and folders in the sidebar.
+
+### Sorting Pages
+
+Add `order` to page frontmatter. Lower numbers appear first. Pages without `order` appear at the end.
+
+```mdx
+---
+title: Introduction
+order: 1
+---
+```
+
+```mdx
+---
+title: Installation
+order: 2
+---
+```
+
+Alternatively, use the `pages` array in `meta.json` to explicitly order pages within a folder:
+
+```json
+{
+  "pages": ["introduction", "installation", "configuration"]
+}
+```
+
+### Sorting Folders
+
+Add `order` to the folder's `meta.json`. This works even for folders without an index page.
+
+```
+docs/
+├── getting-started/
+│   └── meta.json        ← {"title": "Getting Started", "order": 1}
+├── guides/
+│   └── meta.json        ← {"title": "Guides", "order": 2}
+└── api/
+    └── meta.json        ← {"title": "API Reference", "order": 3}
+```
+
+`getting-started/meta.json`:
+```json
+{
+  "title": "Getting Started",
+  "order": 1
+}
+```
+
+`guides/meta.json`:
+```json
+{
+  "title": "Guides",
+  "order": 2
+}
+```
+
+Folders without `order` appear after all ordered folders.
+
+If a folder has an index page (`readme.mdx` or `index.mdx`), you can also set `order` in the index page's frontmatter as a fallback. The `meta.json` `order` takes priority.
+
+---
+
 ## Markdown URLs
 
 Every page has a `.md` URL that returns raw markdown:

--- a/examples/basic/content/docs/features.mdx
+++ b/examples/basic/content/docs/features.mdx
@@ -190,7 +190,7 @@ docs/
 
 Folders without `order` appear after all ordered folders.
 
-If a folder has an index page (`readme.mdx` or `index.mdx`), you can also set `order` in the index page's frontmatter as a fallback. The `meta.json` `order` takes priority.
+Folder sorting is controlled **only** by `meta.json` `order`. The index page frontmatter `order` does not affect folder position — it only controls the page's position within the folder.
 
 ---
 

--- a/packages/chronicle/src/lib/source.ts
+++ b/packages/chronicle/src/lib/source.ts
@@ -143,8 +143,7 @@ function getOrder(node: Node, pageOrderMap: Map<string, number>, folderOrderMap:
   if (node.type === 'page') return pageOrderMap.get(node.url);
   if (node.type === 'folder') {
     const folderPath = getFolderPath(node);
-    if (folderPath && folderOrderMap.has(folderPath)) return folderOrderMap.get(folderPath);
-    if (node.index) return pageOrderMap.get(node.index.url);
+    if (folderPath) return folderOrderMap.get(folderPath);
   }
   return undefined;
 }

--- a/packages/chronicle/src/lib/source.ts
+++ b/packages/chronicle/src/lib/source.ts
@@ -120,14 +120,31 @@ export function invalidate() {
   cachedNavMap = null;
 }
 
+function getFolderPath(node: Folder): string | null {
+  const firstPage = findFirstPage(node);
+  if (!firstPage) return null;
+  const parts = firstPage.url.split('/').filter(Boolean);
+  parts.pop();
+  return '/' + parts.join('/');
+}
+
+function findFirstPage(node: Folder): { url: string } | null {
+  for (const child of node.children) {
+    if (child.type === 'page') return child;
+    if (child.type === 'folder') {
+      const found = findFirstPage(child);
+      if (found) return found;
+    }
+  }
+  return node.index ?? null;
+}
+
 function getOrder(node: Node, pageOrderMap: Map<string, number>, folderOrderMap: Map<string, number>): number | undefined {
   if (node.type === 'page') return pageOrderMap.get(node.url);
   if (node.type === 'folder') {
-    if (node.index) {
-      const fromMeta = folderOrderMap.get(node.index.url);
-      if (fromMeta !== undefined) return fromMeta;
-      return pageOrderMap.get(node.index.url);
-    }
+    const folderPath = getFolderPath(node);
+    if (folderPath && folderOrderMap.has(folderPath)) return folderOrderMap.get(folderPath);
+    if (node.index) return pageOrderMap.get(node.index.url);
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary

- Fix folder sorting by `meta.json` `order` — folders without index pages were not sorting because the logic relied on `node.index.url` which was `undefined`
- Derive folder path from first child page URL to match against `folderOrderMap`
- Remove index page frontmatter `order` fallback for folder sorting — folders sort **only** by `meta.json` `order`
- Add sorting documentation for pages and folders

## Changes

- `source.ts`: derive folder path via `getFolderPath()`, remove `pageOrderMap` fallback for folders
- `features.mdx`: add "Sorting Pages and Folders" section

## Test plan

- [ ] Create `meta.json` with `order` in folders — sidebar sorts correctly
- [ ] Works for folders without index pages
- [ ] Index page frontmatter `order` does NOT affect folder position
- [ ] Index page frontmatter `order` still sorts the page within the folder
- [ ] Folders without `order` appear at the end