### PR TITLE
fix: encode slug segments in api/page URL

### DIFF
--- a/packages/chronicle/src/lib/page-context.tsx
+++ b/packages/chronicle/src/lib/page-context.tsx
@@ -116,7 +116,7 @@ export function PageProvider({
   const fetchPageData = useCallback(async (slug: string[]): Promise<PageData> => {
     const apiPath = slug.length === 0
       ? '/api/page'
-      : `/api/page?slug=${slug.join(',')}`;
+      : `/api/page?slug=${slug.map(s => encodeURIComponent(s)).join(',')}`;
     const res = await fetch(apiPath);
     if (!res.ok) throw new Error(String(res.status));
     return res.json();


### PR DESCRIPTION
## Summary

Slug segments containing `&` (e.g., `package&speed`) were breaking the `/api/page` query string — the `&` was parsed as a query parameter separator instead of part of the slug value.

Fix: encode each slug segment with `encodeURIComponent` before joining with `,`.

## Test plan

- [ ] Navigate to a page with `&` in the path (e.g., `/docs/package&speed`) — loads correctly
- [ ] Pages without special characters still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)