### PR TITLE
fix: auto-select database connector based on deploy preset

### DIFF
--- a/packages/chronicle/src/server/vite-config.ts
+++ b/packages/chronicle/src/server/vite-config.ts
@@ -12,6 +12,19 @@ import remarkResolveLinks from '../lib/remark-resolve-links';
 import remarkReadingTime from 'remark-reading-time';
 import remarkUnusedDirectives from '../lib/remark-unused-directives';
 
+function getDatabaseConnector(preset?: string): { connector: string; options?: Record<string, unknown> } {
+  switch (preset) {
+    case 'bun':
+      return { connector: 'bun-sqlite', options: { name: 'chronicle-search' } };
+    case 'cloudflare':
+    case 'cloudflare-pages':
+    case 'cloudflare-module':
+      return { connector: 'cloudflare-d1', options: { bindingName: 'CHRONICLE_DB' } };
+    default:
+      return { connector: 'sqlite', options: { name: 'chronicle-search' } };
+  }
+}
+
 function resolveOutputDir(projectRoot: string, preset?: string): string {
   if (preset === 'vercel' || preset === 'vercel-static') return path.resolve(projectRoot, '.vercel/output');
   return path.resolve(projectRoot, '.output');
@@ -140,10 +153,7 @@ export async function createViteConfig(
         database: true,
       },
       database: {
-        default: {
-          connector: 'sqlite',
-          options: { name: 'chronicle-search' },
-        },
+        default: getDatabaseConnector(preset),
       },
     },
   };


### PR DESCRIPTION
## Summary

Auto-select the Nitro database connector based on the deploy preset instead of hardcoding `sqlite`.

See [Nitro Database Connectors](https://nitro.build/docs/database#connectors) for full list.

| Preset | Connector |
|---|---|
| `bun` | `bun-sqlite` |
| `cloudflare` / `cloudflare-pages` / `cloudflare-module` | `cloudflare-d1` |
| Default (node, vercel, etc.) | `sqlite` |

## Test plan

- [ ] Default dev server uses `sqlite` connector
- [ ] `--preset bun` uses `bun-sqlite`
- [ ] Build passes for all presets