### PR TITLE
fix: handle SIGINT/SIGTERM for graceful shutdown in Docker

### DIFF
--- a/packages/chronicle/src/cli/commands/dev.ts
+++ b/packages/chronicle/src/cli/commands/dev.ts
@@ -29,10 +29,15 @@ export const devCommand = new Command('dev')
     await server.listen();
     server.printUrls();
 
+    let shuttingDown = false;
     const shutdown = async () => {
-      await server.close();
+      if (shuttingDown) return;
+      shuttingDown = true;
+      try {
+        await server.close();
+      } catch { /* ignore close errors */ }
       process.exit(0);
     };
-    process.on('SIGINT', shutdown);
-    process.on('SIGTERM', shutdown);
+    process.once('SIGINT', shutdown);
+    process.once('SIGTERM', shutdown);
   });

--- a/packages/chronicle/src/cli/commands/dev.ts
+++ b/packages/chronicle/src/cli/commands/dev.ts
@@ -28,4 +28,11 @@ export const devCommand = new Command('dev')
 
     await server.listen();
     server.printUrls();
+
+    const shutdown = async () => {
+      await server.close();
+      process.exit(0);
+    };
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
   });

--- a/packages/chronicle/src/cli/commands/start.ts
+++ b/packages/chronicle/src/cli/commands/start.ts
@@ -26,4 +26,8 @@ export const startCommand = new Command('start')
     });
 
     server.printUrls();
+
+    const shutdown = () => process.exit(0);
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
   });

--- a/packages/chronicle/src/cli/commands/start.ts
+++ b/packages/chronicle/src/cli/commands/start.ts
@@ -27,7 +27,15 @@ export const startCommand = new Command('start')
 
     server.printUrls();
 
-    const shutdown = () => process.exit(0);
-    process.on('SIGINT', shutdown);
-    process.on('SIGTERM', shutdown);
+    let shuttingDown = false;
+    const shutdown = async () => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      try {
+        await server.close();
+      } catch { /* ignore close errors */ }
+      process.exit(0);
+    };
+    process.once('SIGINT', shutdown);
+    process.once('SIGTERM', shutdown);
   });


### PR DESCRIPTION
## Summary

Dev and start commands now handle SIGINT/SIGTERM signals to gracefully close the Vite server and exit. Fixes Docker container not stopping on Ctrl+C.

For Docker, also recommend using `--init` flag or tini:

```dockerfile
RUN apk add --no-cache tini
ENTRYPOINT ["/sbin/tini", "--"]
```

## Test plan

- [ ] `chronicle dev` — Ctrl+C stops the server
- [ ] `chronicle start` — Ctrl+C stops the server
- [ ] Docker container stops on `docker stop` (SIGTERM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)