### PR TITLE
feat: add favicon links from public folder

### DIFF
--- a/packages/chronicle/src/server/entry-server.tsx
+++ b/packages/chronicle/src/server/entry-server.tsx
@@ -115,6 +115,8 @@ export default {
         <head>
           <meta charSet="UTF-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+          <link rel="icon" href="/favicon.ico" />
+          <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
           {assets.css.map((attr: { href: string }) => (
             <link key={attr.href} rel="stylesheet" {...attr} />
           ))}


### PR DESCRIPTION
## Summary

Add favicon link tags to the SSR HTML head. Looks for `favicon.ico` and `favicon.svg` from the `public/` directory.

## Test plan

- [ ] Place `favicon.svg` in `public/` — shows in browser tab
- [ ] Place `favicon.ico` in `public/` — fallback for older browsers