### PR TITLE
fix: chronicle start runs Nitro production server

### DIFF
--- a/packages/chronicle/src/cli/commands/start.ts
+++ b/packages/chronicle/src/cli/commands/start.ts
@@ -1,41 +1,58 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
 import chalk from 'chalk';
 import { Command } from 'commander';
 import { loadCLIConfig } from '@/cli/utils/config';
-import { PACKAGE_ROOT } from '@/cli/utils/resolve';
-import { linkContent } from '@/cli/utils/scaffold';
+
+function resolveServerEntry(projectRoot: string, preset?: string): string {
+  if (preset === 'vercel' || preset === 'vercel-static') {
+    return path.resolve(projectRoot, '.vercel/output/server/index.mjs');
+  }
+  return path.resolve(projectRoot, '.output/server/index.mjs');
+}
 
 export const startCommand = new Command('start')
   .description('Start production server')
   .option('-p, --port <port>', 'Port number', '3000')
   .option('--config <path>', 'Path to chronicle.yaml')
-  .option('--host <host>', 'Host address', 'localhost')
+  .option('--host <host>', 'Host address', '0.0.0.0')
+  .option('--preset <preset>', 'Deploy preset (must match build preset)')
   .action(async options => {
-    const { config, projectRoot, configPath } = await loadCLIConfig(options.config);
-    const port = parseInt(options.port, 10);
-    await linkContent(projectRoot, config);
+    const { config, projectRoot } = await loadCLIConfig(options.config);
+    const preset = options.preset ?? config.preset;
+    const serverEntry = resolveServerEntry(projectRoot, preset);
+
+    const exists = await fs.access(serverEntry).then(() => true, () => false);
+    if (!exists) {
+      console.error(chalk.red(`No build found at ${serverEntry}`));
+      console.error(chalk.red('Run `chronicle build` first.'));
+      process.exit(1);
+    }
 
     console.log(chalk.cyan('Starting production server...'));
 
-    const { preview } = await import('vite');
-    const { createViteConfig } = await import('@/server/vite-config');
-
-    const viteConfig = await createViteConfig({ packageRoot: PACKAGE_ROOT, projectRoot, configPath });
-    const server = await preview({
-      ...viteConfig,
-      preview: { port, host: options.host }
+    const child = spawn(process.execPath, [serverEntry], {
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        PORT: options.port,
+        HOST: options.host,
+      },
     });
 
-    server.printUrls();
-
     let shuttingDown = false;
-    const shutdown = async () => {
+    const shutdown = () => {
       if (shuttingDown) return;
       shuttingDown = true;
       try {
-        await server.close();
-      } catch { /* ignore close errors */ }
-      process.exit(0);
+        child.kill('SIGTERM');
+      } catch { /* ignore if already exited */ }
     };
     process.once('SIGINT', shutdown);
     process.once('SIGTERM', shutdown);
+
+    child.on('exit', (code) => {
+      process.exit(code ?? 0);
+    });
   });


### PR DESCRIPTION
## Summary

`chronicle start` was using Vite `preview()` — a static file server that doesn't run Nitro SSR, API routes, or search. Now it spawns `node .output/server/index.mjs` (the actual Nitro production server).

### Before
- Used Vite preview (static files only)
- No SSR, no API routes, no search
- `allowedHosts` errors in Docker

### After
- Runs Nitro production server
- Full SSR + API routes + search
- Checks build exists, clear error message if not
- Forwards PORT/HOST env vars
- Signal forwarding to child process

## Test plan

- [ ] `chronicle build && chronicle start` — full SSR works
- [ ] API routes (`/api/search`, `/api/health`) respond
- [ ] Ctrl+C stops the server
- [ ] Without build → shows "Run chronicle build first" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)