### PR TITLE
fix: prevent API markdown route from intercepting SSR

### DIFF
--- a/packages/chronicle/src/server/routes/apis-md.ts
+++ b/packages/chronicle/src/server/routes/apis-md.ts
@@ -8,7 +8,7 @@ import { generateCurl } from '@/lib/snippet-generators'
 
 export default defineHandler(async event => {
   const pathname = event.path || event.req.url?.split('?')[0] || ''
-  if (!pathname.endsWith('.md')) return
+  if (!pathname.startsWith('/apis/') || !pathname.endsWith('.md')) return
 
   const stripped = pathname.replace(/\.md$/, '').replace(/^\/apis\//, '')
   const slug = stripped.split('/').filter(Boolean)


### PR DESCRIPTION
## Summary
- `apis/[...slug].md.ts` catch-all route intercepted all `/apis/**` requests, returning empty 200 for non-`.md` paths before SSR handler could process them
- Moved route to `apis-md.ts` (outside `apis/` directory) and added `pathname.startsWith('/apis/')` guard

## Test plan
- [ ] `curl http://localhost:4000/apis/petstore/findPetsByStatus` returns full HTML (was empty)
- [ ] `curl http://localhost:4000/apis/petstore/findPetsByStatus.md` still returns markdown
- [ ] Non-API doc pages unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)