### PR TITLE
fix: move API markdown route to utils to prevent SSR interception

### DIFF
--- a/packages/chronicle/src/server/routes/[...slug].md.ts
+++ b/packages/chronicle/src/server/routes/[...slug].md.ts
@@ -3,11 +3,15 @@ import matter from 'gray-matter';
 import { defineHandler, HTTPError } from 'nitro';
 import { getPage, getOriginalPath } from '@/lib/source';
 import { safePath } from '@/server/utils/safe-path';
+import { handleApiMarkdown } from '@/server/utils/api-markdown';
 
 export default defineHandler(async event => {
   const pathname = event.path || event.req.url?.split('?')[0] || '';
   if (!pathname.endsWith('.md')) return;
-  if (pathname.startsWith('/apis/')) return;
+
+  if (pathname.startsWith('/apis/')) {
+    return handleApiMarkdown(pathname);
+  }
 
   const stripped = pathname.replace(/\.md$/, '');
   const parts = stripped === '/index' || stripped === '/'

--- a/packages/chronicle/src/server/utils/api-markdown.ts
+++ b/packages/chronicle/src/server/utils/api-markdown.ts
@@ -1,15 +1,12 @@
 import type { OpenAPIV3 } from 'openapi-types'
-import { defineHandler, HTTPError } from 'nitro'
+import { HTTPError } from 'nitro'
 import { loadConfig } from '@/lib/config'
 import { loadApiSpecs } from '@/lib/openapi'
 import { findApiOperation } from '@/lib/api-routes'
 import { flattenSchema, generateExampleJson, type SchemaField } from '@/lib/schema'
 import { generateCurl } from '@/lib/snippet-generators'
 
-export default defineHandler(async event => {
-  const pathname = event.path || event.req.url?.split('?')[0] || ''
-  if (!pathname.endsWith('.md')) return
-
+export async function handleApiMarkdown(pathname: string) {
   const stripped = pathname.replace(/\.md$/, '').replace(/^\/apis\//, '')
   const slug = stripped.split('/').filter(Boolean)
   if (slug.length < 2) {
@@ -26,7 +23,7 @@ export default defineHandler(async event => {
 
   const md = generateApiMarkdown(match.method, match.path, match.operation, match.spec.server.url, match.spec.auth)
   return new Response(md, { headers: { 'Content-Type': 'text/markdown; charset=utf-8' } })
-})
+}
 
 function generateApiMarkdown(
   method: string,


### PR DESCRIPTION
## Summary
- `apis/[...slug].md.ts` catch-all intercepted all `/apis/**` requests, returning empty 200 for non-`.md` paths, blocking SSR
- Moved API markdown logic to `server/utils/api-markdown.ts` as an exported function
- Root `[...slug].md.ts` now calls `handleApiMarkdown()` for `/apis/` paths instead of skipping them

## Test plan
- [x] `/apis/petstore/findPetsByStatus` returns full SSR HTML (was empty 200)
- [x] `/apis/petstore/findPetsByStatus.md` still returns markdown
- [x] `/docs/getting-started` SSR unaffected
- [x] `/docs/getting-started.md` markdown unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)