### PR TITLE
fix: skip prefetching for sidebar top links

### DIFF
--- a/packages/chronicle/src/components/ui/PrefetchProvider.tsx
+++ b/packages/chronicle/src/components/ui/PrefetchProvider.tsx
@@ -47,7 +47,7 @@ export function PrefetchProvider({ children }: { children: React.ReactNode }) {
     );
 
     const observeLinks = () => {
-      document.querySelectorAll('a[href]:not([data-prefetch-observed]):not([${NO_PREFETCH_ATTR}])').forEach((link) => {
+      document.querySelectorAll(`a[href]:not([data-prefetch-observed]):not([${NO_PREFETCH_ATTR}])`).forEach((link) => {
         const pathname = resolvePathname(link.getAttribute('href'));
         if (pathname) {
           link.setAttribute('data-prefetch-observed', '');

--- a/packages/chronicle/src/components/ui/PrefetchProvider.tsx
+++ b/packages/chronicle/src/components/ui/PrefetchProvider.tsx
@@ -16,14 +16,14 @@ export function PrefetchProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     const handleMouseOver = (e: MouseEvent) => {
       const anchor = (e.target as HTMLElement).closest?.('a[href]');
-      if (!anchor) return;
+      if (!anchor || anchor.hasAttribute('data-no-prefetch')) return;
       const pathname = resolvePathname(anchor.getAttribute('href'));
       if (pathname) prefetchPageData(pathname);
     };
 
     const handleFocusIn = (e: FocusEvent) => {
       const anchor = (e.target as HTMLElement).closest?.('a[href]');
-      if (!anchor) return;
+      if (!anchor || anchor.hasAttribute('data-no-prefetch')) return;
       const pathname = resolvePathname(anchor.getAttribute('href'));
       if (pathname) prefetchPageData(pathname);
     };
@@ -45,7 +45,7 @@ export function PrefetchProvider({ children }: { children: React.ReactNode }) {
     );
 
     const observeLinks = () => {
-      document.querySelectorAll('a[href]:not([data-prefetch-observed])').forEach((link) => {
+      document.querySelectorAll('a[href]:not([data-prefetch-observed]):not([data-no-prefetch])').forEach((link) => {
         const pathname = resolvePathname(link.getAttribute('href'));
         if (pathname) {
           link.setAttribute('data-prefetch-observed', '');

--- a/packages/chronicle/src/components/ui/PrefetchProvider.tsx
+++ b/packages/chronicle/src/components/ui/PrefetchProvider.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from 'react';
 import { prefetchPageData } from '@/lib/preload';
 
+const NO_PREFETCH_ATTR = 'data-no-prefetch';
+
 function resolvePathname(href: string | null): string | null {
   if (!href) return null;
   try {
@@ -16,14 +18,14 @@ export function PrefetchProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     const handleMouseOver = (e: MouseEvent) => {
       const anchor = (e.target as HTMLElement).closest?.('a[href]');
-      if (!anchor || anchor.hasAttribute('data-no-prefetch')) return;
+      if (!anchor || anchor.hasAttribute(NO_PREFETCH_ATTR)) return;
       const pathname = resolvePathname(anchor.getAttribute('href'));
       if (pathname) prefetchPageData(pathname);
     };
 
     const handleFocusIn = (e: FocusEvent) => {
       const anchor = (e.target as HTMLElement).closest?.('a[href]');
-      if (!anchor || anchor.hasAttribute('data-no-prefetch')) return;
+      if (!anchor || anchor.hasAttribute(NO_PREFETCH_ATTR)) return;
       const pathname = resolvePathname(anchor.getAttribute('href'));
       if (pathname) prefetchPageData(pathname);
     };
@@ -45,7 +47,7 @@ export function PrefetchProvider({ children }: { children: React.ReactNode }) {
     );
 
     const observeLinks = () => {
-      document.querySelectorAll('a[href]:not([data-prefetch-observed]):not([data-no-prefetch])').forEach((link) => {
+      document.querySelectorAll('a[href]:not([data-prefetch-observed]):not([${NO_PREFETCH_ATTR}])').forEach((link) => {
         const pathname = resolvePathname(link.getAttribute('href'));
         if (pathname) {
           link.setAttribute('data-prefetch-observed', '');

--- a/packages/chronicle/src/themes/default/Layout.tsx
+++ b/packages/chronicle/src/themes/default/Layout.tsx
@@ -138,7 +138,7 @@ export function Layout({
                         <DocumentTextIcon width={16} height={16} />
                       )}
                       classNames={{ root: styles.topLinkItem, text: styles.topLinkText }}
-                      render={<RouterLink to={entry.href} />}
+                      render={<RouterLink to={entry.href} data-no-prefetch />}
                     >
                       {entry.label}
                     </Sidebar.Item>
@@ -154,7 +154,7 @@ export function Layout({
                         <CodeBracketSquareIcon width={16} height={16} />
                       )}
                       classNames={{ root: styles.topLinkItem, text: styles.topLinkText }}
-                      render={<RouterLink to={api.basePath} />}
+                      render={<RouterLink to={api.basePath} data-no-prefetch />}
                     >
                       {api.name} API
                     </Sidebar.Item>


### PR DESCRIPTION
## Summary
- Add `data-no-prefetch` attribute check in `PrefetchProvider` (mouseover, focusin, IntersectionObserver)
- Apply `data-no-prefetch` to content and API top links in sidebar — these are index routes that return 404 from `/api/page`

## Test plan
- [x] Hovering sidebar top links no longer triggers `/api/page` calls
- [x] Regular doc page links still prefetch on hover
- [x] No 404 errors in network tab from prefetcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)