### PR TITLE
fix: add custom error handler and fix hydration errors

### DIFF
--- a/packages/chronicle/src/components/mdx/paragraph.tsx
+++ b/packages/chronicle/src/components/mdx/paragraph.tsx
@@ -1,7 +1,7 @@
 import { Children, isValidElement, type ComponentProps } from 'react'
 import styles from './paragraph.module.css'
 
-const BLOCK_ELEMENTS = new Set(['summary', 'details', 'div', 'table', 'ul', 'ol'])
+const BLOCK_ELEMENTS = new Set(['summary', 'details', 'div', 'table', 'ul', 'ol', 'p'])
 
 function hasBlockChild(children: React.ReactNode): boolean {
   return Children.toArray(children).some(

--- a/packages/chronicle/src/lib/preload.ts
+++ b/packages/chronicle/src/lib/preload.ts
@@ -28,8 +28,13 @@ function isApisRoute(pathname: string): boolean {
   return pathname === '/apis' || pathname.startsWith('/apis/');
 }
 
+function hasFileExtension(pathname: string): boolean {
+  const lastSegment = pathname.split('/').pop() ?? '';
+  return lastSegment.includes('.');
+}
+
 export function prefetchPageData(pathname: string) {
-  if (isApisRoute(pathname)) return;
+  if (isApisRoute(pathname) || hasFileExtension(pathname)) return;
   queryClient.prefetchQuery({
     queryKey: pageDataQueryKey(pathname),
     queryFn: () => fetchPageDataByPathname(pathname),

--- a/packages/chronicle/src/server/error.ts
+++ b/packages/chronicle/src/server/error.ts
@@ -1,0 +1,11 @@
+import { defineErrorHandler, HTTPError } from 'nitro';
+
+export default defineErrorHandler((error, _event) => {
+  const status = HTTPError.isError(error) ? error.status : 500;
+  const message = error.message || 'Internal Server Error';
+
+  return new Response(JSON.stringify({ error: true, status, message }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+});

--- a/packages/chronicle/src/server/vite-config.ts
+++ b/packages/chronicle/src/server/vite-config.ts
@@ -145,6 +145,7 @@ export async function createViteConfig(
     },
     nitro: {
       logLevel: 2,
+      errorHandler: path.resolve(packageRoot, 'src/server/error.ts'),
       publicAssets: [{ dir: path.resolve(projectRoot, 'public') }],
       output: {
         dir: resolveOutputDir(projectRoot, preset),


### PR DESCRIPTION
## Summary
- Add Nitro custom error handler to return proper JSON for HTTPError (fixes Parse Error in Vite 8 dev mode)
- Fix nested `<p>` hydration error by adding `'p'` to block element detection in MdxParagraph
- Skip prefetching for URLs with file extensions (e.g. `/openapi.json`)

## Test plan
- [ ] Visit `/developer/gettingstarted/introduction` — no hydration error in console
- [ ] Hover `/openapi.json` link — no Parse Error overlay
- [ ] `curl /api/page?slug=nonexistent` returns `{"error":true,"status":404}`
- [ ] `curl /api/page?slug=developer,gettingstarted,introduction` returns page data

🤖 Generated with [Claude Code](https://claude.com/claude-code)