### PR TITLE
fix: trigger search index build from readiness probe

### DIFF
--- a/packages/chronicle/src/cli/commands/dev.ts
+++ b/packages/chronicle/src/cli/commands/dev.ts
@@ -9,6 +9,7 @@ export const devCommand = new Command('dev')
   .option('-p, --port <port>', 'Port number', '3000')
   .option('--config <path>', 'Path to chronicle.yaml')
   .option('--host <host>', 'Host address', 'localhost')
+  .option('--preset <preset>', 'Deploy preset (bun, node-server, etc.)')
   .action(async options => {
     const { config, projectRoot, configPath } = await loadCLIConfig(options.config);
     const port = parseInt(options.port, 10);
@@ -20,7 +21,7 @@ export const devCommand = new Command('dev')
     const { createServer } = await import('vite');
     const { createViteConfig } = await import('@/server/vite-config');
 
-    const viteConfig = await createViteConfig({ packageRoot: PACKAGE_ROOT, projectRoot, configPath });
+    const viteConfig = await createViteConfig({ packageRoot: PACKAGE_ROOT, projectRoot, configPath, preset: options.preset });
     const server = await createServer({
       ...viteConfig,
       server: { ...viteConfig.server, port, host: options.host }

--- a/packages/chronicle/src/server/api/ready.ts
+++ b/packages/chronicle/src/server/api/ready.ts
@@ -1,15 +1,19 @@
 import { defineHandler } from 'nitro';
-import { isSearchReady } from './search';
+import { ensureIndex, isSearchReady } from './search';
+import { LATEST_CONTEXT } from '@/lib/version-source';
 
-export default defineHandler(() => {
-  const searchReady = isSearchReady();
+export default defineHandler(async () => {
+  ensureIndex(LATEST_CONTEXT).catch(e => console.error('[search:index]', e));
 
-  if (!searchReady) {
-    return Response.json(
-      { status: 'not_ready', search: false },
-      { status: 503 },
-    );
+  if (!isSearchReady()) {
+    return new Response(JSON.stringify({ status: 'not_ready', search: false }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    });
   }
 
-  return Response.json({ status: 'ready', search: true });
+  return new Response(JSON.stringify({ status: 'ready', search: true }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
 });


### PR DESCRIPTION
## Summary
- Readiness probe (`/api/ready`) now triggers `ensureIndex` on first hit, building the search index without waiting for a search request
- Adds `--preset` flag to `chronicle dev` command so `bun-sqlite` connector is used when running under Bun

## Test plan
- [ ] `curl /api/ready` → 503 first call, 200 on subsequent calls
- [ ] `chronicle dev --preset bun` uses bun-sqlite connector
- [ ] K8s readiness probe passes after index build completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)