### PR TITLE
fix: center paper theme content relative to viewport

### DIFF
--- a/packages/chronicle/src/themes/paper/Layout.module.css
+++ b/packages/chronicle/src/themes/paper/Layout.module.css
@@ -77,7 +77,12 @@
 
 .content {
   flex: 1;
+  margin-left: calc(-1 * var(--paper-sidebar-width));
   background: var(--rs-color-background-neutral-primary);
+}
+
+.contentFull {
+  margin-left: 0;
 }
 
 .hiddenTrigger {

--- a/packages/chronicle/src/themes/paper/Layout.tsx
+++ b/packages/chronicle/src/themes/paper/Layout.tsx
@@ -82,7 +82,7 @@ function LayoutInner({
             ) : null}
           </aside>
         ) : null}
-        <div className={cx(styles.content, classNames?.content)}>
+        <div className={cx(styles.content, classNames?.content, { [styles.contentFull]: !showSidebar })}>
           {config.search?.enabled && <Search classNames={{ trigger: styles.hiddenTrigger }} />}
           {children}
         </div>

--- a/packages/chronicle/src/themes/paper/Page.module.css
+++ b/packages/chronicle/src/themes/paper/Page.module.css
@@ -1,15 +1,9 @@
 .main {
   flex: 1;
   width: 100%;
-  max-width: calc(1024px + var(--rs-space-17));
+  max-width: 1024px;
   margin: 0 auto;
   padding-top: var(--rs-space-12);
-  padding-right: var(--rs-space-17);
-}
-
-.readerMode {
-  padding-right: 0;
-  margin: 0 auto;
 }
 
 .navbar {

--- a/packages/chronicle/src/themes/paper/Page.tsx
+++ b/packages/chronicle/src/themes/paper/Page.tsx
@@ -41,7 +41,7 @@ export function Page({ page, tree }: ThemePageProps) {
 
   return (
     <>
-      <main className={`${styles.main} ${readerMode ? styles.readerMode : ''}`}>
+      <main className={styles.main}>
         <div className={styles.navbar}>
           <div className={styles.navLeft}>
             <div className={styles.arrows}>


### PR DESCRIPTION
## Summary
- Content area centers to full viewport width using negative margin offset for sidebar
- Reader mode toggle no longer causes content to shift position
- Removed padding-right compensation and readerMode CSS class from Page

## Test plan
- [ ] Open paper theme — content is centered to viewport, sidebar overlaps left edge
- [ ] Toggle reader mode — content stays in place, no horizontal shift
- [ ] Check landing page (hideSidebar) — content centered without offset

🤖 Generated with [Claude Code](https://claude.com/claude-code)