### PR TITLE
refactor: migrate search to react-query

### DIFF
--- a/packages/chronicle/src/components/ui/search.tsx
+++ b/packages/chronicle/src/components/ui/search.tsx
@@ -6,7 +6,7 @@ import {
 import { Badge, Command, IconButton, Text } from '@raystack/apsara';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { debounce } from 'lodash-es';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { MethodBadge } from '@/components/api/method-badge';
 import { usePageContext } from '@/lib/page-context';
@@ -42,8 +42,8 @@ export function Search({ classNames }: SearchProps) {
   const { version } = usePageContext();
   const tag = version.dir ?? undefined;
 
-  const updateDebouncedSearch = useMemo(
-    () => debounce((value: string) => setDebouncedSearch(value), 150),
+  const updateDebouncedSearch = useCallback(
+    debounce((value: string) => setDebouncedSearch(value), 150),
     []
   );
 

--- a/packages/chronicle/src/components/ui/search.tsx
+++ b/packages/chronicle/src/components/ui/search.tsx
@@ -4,8 +4,9 @@ import {
   MagnifyingGlassIcon
 } from '@heroicons/react/24/outline';
 import { Badge, Command, IconButton, Text } from '@raystack/apsara';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { debounce } from 'lodash-es';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { MethodBadge } from '@/components/api/method-badge';
 import { usePageContext } from '@/lib/page-context';
@@ -36,57 +37,38 @@ function buildSearchUrl(query: string, tag?: string): string {
 export function Search({ classNames }: SearchProps) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
-  const [results, setResults] = useState<SearchResult[]>([]);
-  const [suggestions, setSuggestions] = useState<SearchResult[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+  const [debouncedSearch, setDebouncedSearch] = useState('');
   const navigate = useNavigate();
   const { version } = usePageContext();
   const tag = version.dir ?? undefined;
-  const abortRef = useRef<AbortController | null>(null);
 
-  const fetchResults = useCallback(async (query: string, signal?: AbortSignal) => {
-    setIsLoading(true);
-    try {
-      const res = await fetch(buildSearchUrl(query, tag), { signal });
-      if (!res.ok || signal?.aborted) return;
-      const data: SearchResult[] = await res.json();
-      if (signal?.aborted) return;
-      if (query) {
-        setResults(data);
-      } else {
-        setSuggestions(data);
-      }
-    } catch (err) {
-      if (err instanceof DOMException && err.name === 'AbortError') return;
-      console.error('Search fetch failed:', err);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [tag]);
-
-  const debouncedSearch = useMemo(
-    () => debounce((query: string) => {
-      abortRef.current?.abort();
-      const controller = new AbortController();
-      abortRef.current = controller;
-      fetchResults(query, controller.signal);
-    }, 150),
-    [fetchResults]
+  const updateDebouncedSearch = useMemo(
+    () => debounce((value: string) => setDebouncedSearch(value), 150),
+    []
   );
+
+  useEffect(() => {
+    updateDebouncedSearch(search);
+    return () => updateDebouncedSearch.cancel();
+  }, [search, updateDebouncedSearch]);
 
   useEffect(() => {
     if (!open) {
       setSearch('');
-      setResults([]);
-      return;
+      setDebouncedSearch('');
     }
-    if (!search) {
-      fetchResults('');
-      return;
-    }
-    debouncedSearch(search);
-    return () => debouncedSearch.cancel();
-  }, [open, search, fetchResults, debouncedSearch]);
+  }, [open]);
+
+  const { data = [], isLoading } = useQuery<SearchResult[]>({
+    queryKey: ['search', debouncedSearch, tag],
+    queryFn: async ({ signal }) => {
+      const res = await fetch(buildSearchUrl(debouncedSearch, tag), { signal });
+      if (!res.ok) throw new Error(String(res.status));
+      return res.json();
+    },
+    enabled: open,
+    placeholderData: keepPreviousData,
+  });
 
   const onSelect = useCallback(
     (url: string) => {
@@ -108,7 +90,7 @@ export function Search({ classNames }: SearchProps) {
     return () => document.removeEventListener('keydown', down);
   }, []);
 
-  const displayResults = deduplicateByUrl(search ? results : suggestions);
+  const displayResults = deduplicateByUrl(data);
 
   return (
     <>

--- a/packages/chronicle/src/components/ui/search.tsx
+++ b/packages/chronicle/src/components/ui/search.tsx
@@ -6,7 +6,7 @@ import {
 import { Badge, Command, IconButton, Text } from '@raystack/apsara';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { debounce } from 'lodash-es';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { MethodBadge } from '@/components/api/method-badge';
 import { usePageContext } from '@/lib/page-context';
@@ -42,8 +42,8 @@ export function Search({ classNames }: SearchProps) {
   const { version } = usePageContext();
   const tag = version.dir ?? undefined;
 
-  const updateDebouncedSearch = useCallback(
-    debounce((value: string) => setDebouncedSearch(value), 150),
+  const updateDebouncedSearch = useMemo(
+    () => debounce((value: string) => setDebouncedSearch(value), 150),
     []
   );
 

--- a/packages/chronicle/src/components/ui/search.tsx
+++ b/packages/chronicle/src/components/ui/search.tsx
@@ -6,7 +6,7 @@ import {
 import { Badge, Command, IconButton, Text } from '@raystack/apsara';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { debounce } from 'lodash-es';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ChangeEvent } from 'react';
 import { useNavigate } from 'react-router';
 import { MethodBadge } from '@/components/api/method-badge';
 import { usePageContext } from '@/lib/page-context';
@@ -47,17 +47,19 @@ export function Search({ classNames }: SearchProps) {
     []
   );
 
-  useEffect(() => {
-    updateDebouncedSearch(search);
-    return () => updateDebouncedSearch.cancel();
-  }, [search, updateDebouncedSearch]);
+  const onSearchChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setSearch(value);
+    updateDebouncedSearch(value);
+  }, [updateDebouncedSearch]);
 
   useEffect(() => {
     if (!open) {
       setSearch('');
       setDebouncedSearch('');
+      updateDebouncedSearch.cancel();
     }
-  }, [open]);
+  }, [open, updateDebouncedSearch]);
 
   const { data = [], isLoading } = useQuery<SearchResult[]>({
     queryKey: ['search', debouncedSearch, tag],
@@ -111,7 +113,7 @@ export function Search({ classNames }: SearchProps) {
               placeholder='Search'
               leadingIcon={<MagnifyingGlassIcon width={16} height={16} />}
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
+              onChange={onSearchChange}
               className={styles.input}
             />
 

--- a/packages/chronicle/src/lib/preload.ts
+++ b/packages/chronicle/src/lib/preload.ts
@@ -40,3 +40,14 @@ export function prefetchPageData(pathname: string) {
     queryFn: () => fetchPageDataByPathname(pathname),
   });
 }
+
+export function prefetchSearchSuggestions() {
+  queryClient.prefetchQuery({
+    queryKey: ['search', '', undefined],
+    queryFn: async () => {
+      const res = await fetch('/api/search');
+      if (!res.ok) throw new Error(String(res.status));
+      return res.json();
+    },
+  });
+}

--- a/packages/chronicle/src/server/entry-client.tsx
+++ b/packages/chronicle/src/server/entry-client.tsx
@@ -7,7 +7,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { mdxComponents } from '@/components/mdx';
 import { getApiConfigsForVersion } from '@/lib/config';
 import { PageProvider } from '@/lib/page-context';
-import { queryClient } from '@/lib/preload';
+import { prefetchSearchSuggestions, queryClient } from '@/lib/preload';
 import { resolveRoute, RouteType } from '@/lib/route-resolver';
 import { resolveVersionFromUrl, type VersionContext } from '@/lib/version-source';
 import type { ChronicleConfig, Frontmatter, PageNavLink, Root, TableOfContents } from '@/types';
@@ -56,6 +56,7 @@ async function hydrate() {
       window as unknown as { __PAGE_DATA__?: EmbeddedData }
     ).__PAGE_DATA__;
 
+    prefetchSearchSuggestions();
     const config: ChronicleConfig = embedded?.config ?? defaultConfig;
     const tree: Root = embedded?.tree ?? { name: 'root', children: [] };
 


### PR DESCRIPTION
## Summary
- Replace manual fetch/abort/debounce in search with `useQuery` + `keepPreviousData`
- Lodash debounce drives `debouncedSearch` state for query key (150ms)
- Prefetch search suggestions on hydration for instant display on dialog open

## Test plan
- [ ] Open search dialog (Cmd/Ctrl+K) — suggestions load instantly
- [ ] Type search query — results appear after debounce
- [ ] Fast typing — no excessive API calls
- [ ] Close and reopen dialog — cached suggestions shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)