### PR TITLE
fix: match link font-size to surrounding content

### DIFF
--- a/packages/chronicle/src/themes/default/Page.module.css
+++ b/packages/chronicle/src/themes/default/Page.module.css
@@ -71,6 +71,10 @@
   margin: var(--rs-space-2) 0;
 }
 
+.content a {
+  font-size: inherit;
+}
+
 .content [role="tablist"] {
   margin-bottom: var(--rs-space-3);
 }

--- a/packages/chronicle/src/themes/paper/Page.module.css
+++ b/packages/chronicle/src/themes/paper/Page.module.css
@@ -204,6 +204,10 @@
   margin-bottom: var(--rs-space-5);
 }
 
+.content a {
+  font-size: inherit;
+}
+
 .content [role="tablist"] {
   margin-bottom: var(--rs-space-3);
 }


### PR DESCRIPTION
## Summary
- Add `font-size: inherit` to `.content a` in both themes
- Links now match the font-size of their parent element

## Test plan
- [ ] Links inside paragraphs match paragraph font-size
- [ ] Links inside list items match list item font-size
- [ ] Standalone links in content area match content font-size

🤖 Generated with [Claude Code](https://claude.com/claude-code)