### PR TITLE
fix: use Apsara typography tokens for heading sizes

### DIFF
--- a/packages/chronicle/src/themes/default/Page.module.css
+++ b/packages/chronicle/src/themes/default/Page.module.css
@@ -27,7 +27,9 @@
 .content h6 {
   margin-top: var(--rs-space-8);
   margin-bottom: var(--rs-space-5);
-  line-height: 1.4;
+  font-family: var(--rs-font-title);
+  font-weight: var(--rs-font-weight-medium);
+  color: var(--rs-color-foreground-base-primary);
 }
 
 .content > :is(h1, h2, h3, h4, h5, h6):first-child {
@@ -35,8 +37,37 @@
 }
 
 .content h1 {
+  font-size: var(--rs-font-size-t4);
+  line-height: var(--rs-line-height-t4);
   margin-top: 0;
   margin-bottom: var(--rs-space-10);
+}
+
+.content h2 {
+  font-size: var(--rs-font-size-t3);
+  line-height: var(--rs-line-height-t3);
+  margin-top: var(--rs-space-8);
+  margin-bottom: var(--rs-space-8);
+}
+
+.content h3 {
+  font-size: var(--rs-font-size-t2);
+  line-height: var(--rs-line-height-t2);
+}
+
+.content h4 {
+  font-size: var(--rs-font-size-t1);
+  line-height: var(--rs-line-height-t1);
+}
+
+.content h5 {
+  font-size: var(--rs-font-size-large);
+  line-height: var(--rs-line-height-large);
+}
+
+.content h6 {
+  font-size: var(--rs-font-size-regular);
+  line-height: var(--rs-line-height-regular);
 }
 
 .content p {
@@ -46,18 +77,6 @@
   font-style: normal;
   font-weight: var(--rs-font-weight-regular);
   line-height: 171.429%;
-}
-
-.content h2 {
-  margin-top: var(--rs-space-8);
-  margin-bottom: var(--rs-space-8);
-  color: var(--rs-color-foreground-base-primary);
-  font-family: var(--rs-font-title);
-  font-size: var(--rs-font-size-t3);
-  font-style: normal;
-  font-weight: var(--rs-font-weight-medium);
-  line-height: var(--rs-line-height-t3);
-  letter-spacing: var(--rs-letter-spacing-t3);
 }
 
 .content ul,

--- a/packages/chronicle/src/themes/paper/Page.module.css
+++ b/packages/chronicle/src/themes/paper/Page.module.css
@@ -147,37 +147,45 @@
 .content h4,
 .content h5,
 .content h6 {
-  line-height: 1.4;
+  font-family: var(--rs-font-title);
+  font-weight: var(--rs-font-weight-medium);
+  color: var(--rs-color-foreground-base-primary);
 }
 
 .content h1 {
+  font-size: var(--rs-font-size-t4);
+  line-height: var(--rs-line-height-t4);
   margin: 2rem 0 1rem;
-  font-size: 2rem;
 }
 
 .content h2 {
+  font-size: var(--rs-font-size-t3);
+  line-height: var(--rs-line-height-t3);
   margin: 1.75rem 0 0.75rem;
-  font-size: 1.5rem;
 }
 
 .content h3 {
+  font-size: var(--rs-font-size-t2);
+  line-height: var(--rs-line-height-t2);
   margin: 1.5rem 0 0.5rem;
-  font-size: 1.25rem;
 }
 
 .content h4 {
+  font-size: var(--rs-font-size-t1);
+  line-height: var(--rs-line-height-t1);
   margin: 1.25rem 0 0.5rem;
-  font-size: 1.1rem;
 }
 
 .content h5 {
+  font-size: var(--rs-font-size-large);
+  line-height: var(--rs-line-height-large);
   margin: 1rem 0 0.5rem;
-  font-size: 1rem;
 }
 
 .content h6 {
+  font-size: var(--rs-font-size-regular);
+  line-height: var(--rs-line-height-regular);
   margin: 1rem 0 0.5rem;
-  font-size: 0.875rem;
 }
 
 .content p {


### PR DESCRIPTION
## Summary
- Replace hardcoded heading font sizes with Apsara design tokens
- h1: `--rs-font-size-t4` (32px), h2: `--rs-font-size-t3` (28px), h3: `--rs-font-size-t2` (24px), h4: `--rs-font-size-t1` (20px), h5: `--rs-font-size-large` (16px), h6: `--rs-font-size-regular` (14px)
- Applied to both default and paper themes

## Test plan
- [ ] Verify h1-h6 render at correct sizes in default theme
- [ ] Verify h1-h6 render at correct sizes in paper theme
- [ ] Check heading hierarchy is visually distinct

🤖 Generated with [Claude Code](https://claude.com/claude-code)