### PR TITLE
fix: add QueryClientProvider to SSR render tree

### DIFF
--- a/packages/chronicle/src/server/entry-server.tsx
+++ b/packages/chronicle/src/server/entry-server.tsx
@@ -14,6 +14,7 @@ import { getFirstApiUrl } from '@/lib/api-routes';
 import { StatusCodes } from 'http-status-codes';
 import { resolveDocsRedirect } from '@/lib/tree-utils';
 import { isLocalImage, isSvg, buildOptimizedUrl, DEFAULT_WIDTH } from '@/lib/image-utils';
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import { useNitroApp } from 'nitro/app';
 import { App } from './App';
 
@@ -136,20 +137,22 @@ export default {
         </head>
         <body>
           <div id="root">
-            <StaticRouter location={pathname}>
-              <ReactRouterProvider>
-                <PageProvider
-                  initialConfig={config}
-                  initialTree={tree}
-                  initialPage={pageData}
-                  initialApiSpecs={apiSpecs}
-                  initialVersion={route.version}
-                  loadMdx={async () => ({ content: null, toc: [] })}
-                >
-                  <App />
-                </PageProvider>
-              </ReactRouterProvider>
-            </StaticRouter>
+            <QueryClientProvider client={new QueryClient()}>
+              <StaticRouter location={pathname}>
+                <ReactRouterProvider>
+                  <PageProvider
+                    initialConfig={config}
+                    initialTree={tree}
+                    initialPage={pageData}
+                    initialApiSpecs={apiSpecs}
+                    initialVersion={route.version}
+                    loadMdx={async () => ({ content: null, toc: [] })}
+                  >
+                    <App />
+                  </PageProvider>
+                </ReactRouterProvider>
+              </StaticRouter>
+            </QueryClientProvider>
           </div>
         </body>
       </html>,


### PR DESCRIPTION
## Summary
- Wrap SSR render tree in QueryClientProvider to fix "No QueryClient set" error
- Search component uses useQuery which requires the provider during SSR

## Test plan
- [x] Docker build + start with Node — no SSR errors
- [x] All 8 smoke tests pass
- [x] SSR renders full HTML with sidebar, navigation, content

Generated with Claude Code