### PR TITLE
fix: use t4 font size for article title

### DIFF
--- a/packages/chronicle/src/themes/default/Page.tsx
+++ b/packages/chronicle/src/themes/default/Page.tsx
@@ -12,7 +12,7 @@ export function Page({ page }: ThemePageProps) {
     <Flex className={styles.page}>
       <article className={styles.article} data-article-content>
         {page.frontmatter.title && (
-          <Headline size="t2" render={<h1 />} className={styles.title}>
+          <Headline size="t4" render={<h1 />} className={styles.title}>
             {page.frontmatter.title}
           </Headline>
         )}

--- a/packages/chronicle/src/themes/paper/Page.module.css
+++ b/packages/chronicle/src/themes/paper/Page.module.css
@@ -94,9 +94,9 @@
 
 .articleTitle {
   font-family: var(--paper-font-body);
-  font-size: var(--rs-space-8);
+  font-size: var(--rs-font-size-t4);
   font-weight: var(--rs-font-weight-medium);
-  line-height: var(--rs-space-10);
+  line-height: var(--rs-line-height-t4);
   letter-spacing: var(--rs-letter-spacing-t1);
   text-align: center;
   color: var(--rs-color-foreground-base-primary);


### PR DESCRIPTION
## Summary
- Article title was smaller than h1 in content
- Default theme: Headline size t2 (24px) -> t4 (32px)
- Paper theme: --rs-space-8 (spacing token) -> --rs-font-size-t4 (32px)

## Test plan
- [ ] Article title same size as h1 in default theme
- [ ] Article title same size as h1 in paper theme

Generated with Claude Code