### PR TITLE
fix: use regular font size for table cells

### DIFF
--- a/packages/chronicle/src/themes/default/Page.module.css
+++ b/packages/chronicle/src/themes/default/Page.module.css
@@ -90,6 +90,15 @@
   margin: var(--rs-space-2) 0;
 }
 
+.content table td {
+  font-size: var(--rs-font-size-regular);
+}
+
+.content table th {
+  font-size: var(--rs-font-size-regular);
+  font-weight: var(--rs-font-weight-medium);
+}
+
 .content a {
   font-size: inherit;
 }

--- a/packages/chronicle/src/themes/paper/Page.module.css
+++ b/packages/chronicle/src/themes/paper/Page.module.css
@@ -213,6 +213,11 @@
   text-overflow: unset;
   word-wrap: break-word;
   vertical-align: top;
+  font-size: var(--rs-font-size-regular);
+}
+
+.content table th {
+  font-weight: var(--rs-font-weight-medium);
 }
 
 .content a {


### PR DESCRIPTION
## Summary
- Override Apsara's small font-size (12px) on th and regular on td
- Both td and th now use --rs-font-size-regular (14px)
- th uses --rs-font-weight-medium for bold headers
- Applied to both default and paper themes

## Test plan
- [ ] Table cell text matches content font size
- [ ] Table headers are bold
- [ ] Both themes consistent

Generated with Claude Code