### PR TITLE
feat: include externalDocs link in API markdown output

### DIFF
--- a/packages/chronicle/src/server/utils/api-markdown.ts
+++ b/packages/chronicle/src/server/utils/api-markdown.ts
@@ -41,6 +41,11 @@ function generateApiMarkdown(
     lines.push(operation.description)
     lines.push('')
   }
+  if (operation.externalDocs?.url) {
+    const label = operation.externalDocs.description || 'external documentation'
+    lines.push(`Read more about this operation in the [${label}](${operation.externalDocs.url}).`)
+    lines.push('')
+  }
   lines.push(`\`${method}\` \`${path}\``)
   lines.push('')
 


### PR DESCRIPTION
## Summary
- Add external documentation link to auto-generated API markdown (`.md` endpoint)
- When an OpenAPI operation has `externalDocs.url`, renders as: "Read more about this operation in the [external documentation](url)."
- Uses `externalDocs.description` as link label when available, falls back to "external documentation"
- Placed after operation description, before method/path line — helps AI agents and LLMs discover related docs

## Test plan
- [ ] Add `externalDocs` to an OpenAPI operation and verify `.md` endpoint includes the link
- [ ] Verify operations without `externalDocs` are unaffected
- [ ] Verify `externalDocs.description` is used as link text when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)