### PR TITLE
fix: left-align top-level sidebar items, indent only nested

### DIFF
--- a/packages/chronicle/src/themes/default/Layout.module.css
+++ b/packages/chronicle/src/themes/default/Layout.module.css
@@ -171,9 +171,13 @@
 }
 
 .groupItems {
-  padding-left: var(--rs-space-4);
+  padding-left: 0;
   padding-bottom: var(--rs-space-3);
   gap: 0;
+}
+
+.navGroup:not([data-depth='0']) .groupItems {
+  padding-left: var(--rs-space-4);
 }
 
 .navGroup {


### PR DESCRIPTION
## Summary
- Remove `padding-left` from top-level sidebar group items (depth 0) so they are left-aligned
- Apply `padding-left` indent only for nested groups (depth >= 1) via `.navGroup:not([data-depth='0']) .groupItems`

## Test plan
- [ ] Verify top-level sidebar links are left-aligned (no indent)
- [ ] Verify nested/child links are indented
- [ ] Verify deeper nesting still indents correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)