### PR TITLE
fix: adjust content spacing for images, paragraphs, and h1

### DIFF
--- a/packages/chronicle/src/themes/default/Page.module.css
+++ b/packages/chronicle/src/themes/default/Page.module.css
@@ -45,8 +45,8 @@
 .content h2 {
   font-size: var(--rs-font-size-t3);
   line-height: var(--rs-line-height-t3);
-  margin-top: var(--rs-space-8);
-  margin-bottom: var(--rs-space-8);
+  margin-top: var(--rs-space-10);
+  margin-bottom: var(--rs-space-7);
 }
 
 .content h3 {

--- a/packages/chronicle/src/themes/default/Page.module.css
+++ b/packages/chronicle/src/themes/default/Page.module.css
@@ -49,6 +49,14 @@
   margin-bottom: var(--rs-space-7);
 }
 
+.content p + h2,
+.content ul + h2,
+.content ol + h2,
+.content div + h2,
+.content table + h2 {
+  margin-top: var(--rs-space-13);
+}
+
 .content h3 {
   font-size: var(--rs-font-size-t2);
   line-height: var(--rs-line-height-t2);

--- a/packages/chronicle/src/themes/default/Page.module.css
+++ b/packages/chronicle/src/themes/default/Page.module.css
@@ -39,8 +39,7 @@
 .content h1 {
   font-size: var(--rs-font-size-t4);
   line-height: var(--rs-line-height-t4);
-  margin-top: 0;
-  margin-bottom: var(--rs-space-10);
+  margin: var(--rs-space-10) 0;
 }
 
 .content h2 {
@@ -77,6 +76,7 @@
   font-style: normal;
   font-weight: var(--rs-font-weight-regular);
   line-height: 171.429%;
+  margin-bottom: var(--rs-space-7);
 }
 
 .content ul,
@@ -110,6 +110,7 @@
 .content img {
   max-width: 100%;
   height: auto;
+  margin: var(--rs-space-7) 0;
 }
 
 .content table {


### PR DESCRIPTION
## Summary
- Add `margin: var(--rs-space-7) 0` (28px) to images in content area
- Add `margin-bottom: var(--rs-space-7)` to paragraphs for consistent spacing between `<p>` tags
- Set h1 to `margin: var(--rs-space-10) 0` for equal top/bottom spacing

## Test plan
- [ ] Verify images have 28px margin top and bottom
- [ ] Verify paragraphs have 28px spacing between them
- [ ] Verify h1 has equal top and bottom margin (--rs-space-10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)