### PR TITLE
fix: design QA sidebar spacing and alignment

### DIFF
--- a/packages/chronicle/src/themes/default/Layout.module.css
+++ b/packages/chronicle/src/themes/default/Layout.module.css
@@ -174,7 +174,7 @@
 
 .groupItems {
   padding-left: 0;
-  padding-bottom: var(--rs-space-3);
+  padding-bottom: 0;
   gap: 0;
 }
 
@@ -192,13 +192,9 @@
 
 .navGroup .navGroupHeader {
   margin: 0;
-  margin-bottom: var(--rs-space-4);
+  margin-bottom: 0;
   padding-top: 0;
   padding-bottom: 0;
-}
-
-.navGroupHeader h3 {
-  margin: 0;
 }
 
 .navGroup[data-depth='1'] .navGroupHeader {

--- a/packages/chronicle/src/themes/default/Layout.module.css
+++ b/packages/chronicle/src/themes/default/Layout.module.css
@@ -197,6 +197,10 @@
   padding-bottom: 0;
 }
 
+.navGroupHeader h3 {
+  margin: 0;
+}
+
 .navGroup[data-depth='1'] .navGroupHeader {
   height: auto;
 }
@@ -226,10 +230,6 @@
   font-weight: var(--rs-font-weight-medium);
   line-height: var(--rs-line-height-small);
   letter-spacing: var(--rs-letter-spacing-small);
-}
-
-.sidebar :global([class*="nav-group"]) h3 {
-  margin: 0;
 }
 
 .navGroupChevron {

--- a/packages/chronicle/src/themes/default/Layout.module.css
+++ b/packages/chronicle/src/themes/default/Layout.module.css
@@ -76,7 +76,6 @@
 
 .topLinks {
   width: 100%;
-  margin-bottom: var(--rs-space-7);
   display: flex;
   flex-direction: column;
   gap: 0;
@@ -193,6 +192,9 @@
 
 .navGroup .navGroupHeader {
   margin: 0;
+  margin-bottom: var(--rs-space-4);
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 .navGroup[data-depth='1'] .navGroupHeader {
@@ -224,6 +226,10 @@
   font-weight: var(--rs-font-weight-medium);
   line-height: var(--rs-line-height-small);
   letter-spacing: var(--rs-letter-spacing-small);
+}
+
+.sidebar :global([class*="nav-group"]) h3 {
+  margin: 0;
 }
 
 .navGroupChevron {

--- a/packages/chronicle/src/themes/default/Layout.module.css
+++ b/packages/chronicle/src/themes/default/Layout.module.css
@@ -77,6 +77,9 @@
 .topLinks {
   width: 100%;
   margin-bottom: var(--rs-space-7);
+  display: flex;
+  flex-direction: column;
+  gap: 0;
 }
 
 .topLinkItem {
@@ -135,7 +138,7 @@
 .cardWrapper {
   flex: 1;
   display: flex;
-  padding: 0 0 var(--rs-space-2) 0;
+  padding: 0;
   min-height: 0;
   background: var(--rs-color-background-base-secondary);
 }
@@ -154,7 +157,7 @@
   align-items: center;
   justify-content: space-between;
   height: var(--navbar-height);
-  padding: var(--rs-space-4) var(--rs-space-7);
+  padding: var(--rs-space-4) var(--rs-space-8);
   background: var(--rs-color-background-base-primary);
   border-bottom: 0.5px solid var(--rs-color-border-base-primary);
   backdrop-filter: blur(1px);


### PR DESCRIPTION
## Summary
Fixes from design QA (sidebar spacing and alignment):

- Sub-nav horizontal padding → 28px per Figma
- Remove extra bottom padding on card wrapper (green padding issue)
- Remove gap between top link items in sidebar
- Section spacing at 24px between nav groups

## Test plan
- [ ] Sidebar items left-aligned with logo
- [ ] No extra padding below content card
- [ ] Sub-nav padding matches Figma (28px)
- [ ] Top links (Documentation/Dev Guide/API) have no extra gap
- [x] Build and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)