### PR TITLE
fix: use endpoint templates in metrics labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
 
       - name: Smoke test dev server
         shell: bash
+        env:
+          NITRO_DEV_RUNNER: ${{ matrix.os == 'windows-latest' && 'self' || '' }}
         run: |
           ./packages/chronicle/bin/chronicle.js dev --config examples/basic/chronicle.yaml --port 3001 &
           DEV_PID=$!

--- a/packages/chronicle/src/server/plugins/telemetry.test.ts
+++ b/packages/chronicle/src/server/plugins/telemetry.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+import { toEndpoint } from './telemetry'
+
+describe('toEndpoint', () => {
+  test('root path', () => {
+    expect(toEndpoint('/')).toBe('/')
+  })
+
+  test('docs pages map to /docs/:slug', () => {
+    expect(toEndpoint('/docs/intro')).toBe('/docs/:slug')
+    expect(toEndpoint('/docs/guides/installation')).toBe('/docs/:slug')
+    expect(toEndpoint('/developer/gettingstarted/auth')).toBe('/docs/:slug')
+  })
+
+  test('api internal routes keep exact path', () => {
+    expect(toEndpoint('/api/page')).toBe('/api/page')
+    expect(toEndpoint('/api/search')).toBe('/api/search')
+    expect(toEndpoint('/api/specs')).toBe('/api/specs')
+    expect(toEndpoint('/api/health')).toBe('/api/health')
+  })
+
+  test('api reference pages map to /apis/:slug', () => {
+    expect(toEndpoint('/apis/petstore/listPets')).toBe('/apis/:slug')
+    expect(toEndpoint('/apis/frontier/getUser')).toBe('/apis/:slug')
+  })
+
+  test('assets map to /assets/:file', () => {
+    expect(toEndpoint('/assets/chunk-abc123.js')).toBe('/assets/:file')
+    expect(toEndpoint('/assets/style-xyz.css')).toBe('/assets/:file')
+  })
+
+  test('content paths map to /_content/:path', () => {
+    expect(toEndpoint('/_content/docs/intro.mdx')).toBe('/_content/:path')
+  })
+
+  test('static routes keep exact path', () => {
+    expect(toEndpoint('/llms.txt')).toBe('/llms.txt')
+    expect(toEndpoint('/robots.txt')).toBe('/robots.txt')
+    expect(toEndpoint('/sitemap.xml')).toBe('/sitemap.xml')
+    expect(toEndpoint('/og')).toBe('/og')
+  })
+
+  test('versioned docs map to /docs/:slug', () => {
+    expect(toEndpoint('/v1/docs/intro')).toBe('/docs/:slug')
+    expect(toEndpoint('/v2/guides/setup')).toBe('/docs/:slug')
+  })
+})

--- a/packages/chronicle/src/server/plugins/telemetry.ts
+++ b/packages/chronicle/src/server/plugins/telemetry.ts
@@ -13,6 +13,24 @@ declare module 'nitro/types' {
   }
 }
 
+const ENDPOINT_MAP: [string, string | null][] = [
+  ['/api/', null],
+  ['/_content/', '/_content/:path'],
+  ['/apis/', '/apis/:slug'],
+  ['/assets/', '/assets/:file'],
+]
+
+const STATIC_ROUTES = new Set(['/llms.txt', '/robots.txt', '/sitemap.xml', '/og'])
+
+function toEndpoint(pathname: string): string {
+  if (pathname === '/') return '/';
+  for (const [prefix, template] of ENDPOINT_MAP) {
+    if (pathname.startsWith(prefix)) return template ?? pathname;
+  }
+  if (STATIC_ROUTES.has(pathname)) return pathname;
+  return '/docs/:slug';
+}
+
 export default definePlugin((nitroApp) => {
   const config = loadConfig()
   if (!config.telemetry?.enabled) return
@@ -42,7 +60,7 @@ export default definePlugin((nitroApp) => {
   })
 
   nitroApp.hooks.hook('chronicle:ssr-rendered', (route, status, durationMs) => {
-    ssrRenderDuration.record(durationMs, { route, status })
+    ssrRenderDuration.record(durationMs, { route: toEndpoint(route), status })
   })
 
   nitroApp.hooks.hook('request', (event) => {
@@ -54,8 +72,8 @@ export default definePlugin((nitroApp) => {
     if (start === undefined) return
     const duration = performance.now() - start
     const method = event.req.method
-    const route = new URL(event.req.url).pathname
-    requestCounter.add(1, { method, route, status: res.status })
-    requestDuration.record(duration, { method, route, status: res.status })
+    const endpoint = toEndpoint(new URL(event.req.url).pathname)
+    requestCounter.add(1, { method, endpoint, status: res.status })
+    requestDuration.record(duration, { method, endpoint, status: res.status })
   })
 })

--- a/packages/chronicle/src/server/plugins/telemetry.ts
+++ b/packages/chronicle/src/server/plugins/telemetry.ts
@@ -17,7 +17,7 @@ const ROUTES = {
   ROOT: '/',
   DOCS: '/docs/:slug',
   API_INTERNAL: '/api/:action',
-  API_PROXY: '/apis/:slug',
+  API_REFERENCE: '/apis/:slug',
   ASSETS: '/assets/:file',
   CONTENT: '/_content/:path',
 } as const
@@ -25,7 +25,7 @@ const ROUTES = {
 const ENDPOINT_MAP: [string, string | null][] = [
   ['/api/', null],
   ['/_content/', ROUTES.CONTENT],
-  ['/apis/', ROUTES.API_PROXY],
+  ['/apis/', ROUTES.API_REFERENCE],
   ['/assets/', ROUTES.ASSETS],
 ]
 

--- a/packages/chronicle/src/server/plugins/telemetry.ts
+++ b/packages/chronicle/src/server/plugins/telemetry.ts
@@ -31,7 +31,7 @@ const ENDPOINT_MAP: [string, string | null][] = [
 
 const STATIC_ROUTES = new Set(['/llms.txt', '/robots.txt', '/sitemap.xml', '/og'])
 
-function toEndpoint(pathname: string): string {
+export function toEndpoint(pathname: string): string {
   if (pathname === '/') return ROUTES.ROOT;
   for (const [prefix, template] of ENDPOINT_MAP) {
     if (pathname.startsWith(prefix)) return template ?? pathname;

--- a/packages/chronicle/src/server/plugins/telemetry.ts
+++ b/packages/chronicle/src/server/plugins/telemetry.ts
@@ -13,22 +13,31 @@ declare module 'nitro/types' {
   }
 }
 
+const ROUTES = {
+  ROOT: '/',
+  DOCS: '/docs/:slug',
+  API: '/api/:action',
+  APIS: '/apis/:slug',
+  ASSETS: '/assets/:file',
+  CONTENT: '/_content/:path',
+} as const
+
 const ENDPOINT_MAP: [string, string | null][] = [
   ['/api/', null],
-  ['/_content/', '/_content/:path'],
-  ['/apis/', '/apis/:slug'],
-  ['/assets/', '/assets/:file'],
+  ['/_content/', ROUTES.CONTENT],
+  ['/apis/', ROUTES.APIS],
+  ['/assets/', ROUTES.ASSETS],
 ]
 
 const STATIC_ROUTES = new Set(['/llms.txt', '/robots.txt', '/sitemap.xml', '/og'])
 
 function toEndpoint(pathname: string): string {
-  if (pathname === '/') return '/';
+  if (pathname === '/') return ROUTES.ROOT;
   for (const [prefix, template] of ENDPOINT_MAP) {
     if (pathname.startsWith(prefix)) return template ?? pathname;
   }
   if (STATIC_ROUTES.has(pathname)) return pathname;
-  return '/docs/:slug';
+  return ROUTES.DOCS;
 }
 
 export default definePlugin((nitroApp) => {

--- a/packages/chronicle/src/server/plugins/telemetry.ts
+++ b/packages/chronicle/src/server/plugins/telemetry.ts
@@ -16,8 +16,8 @@ declare module 'nitro/types' {
 const ROUTES = {
   ROOT: '/',
   DOCS: '/docs/:slug',
-  API: '/api/:action',
-  APIS: '/apis/:slug',
+  API_INTERNAL: '/api/:action',
+  API_PROXY: '/apis/:slug',
   ASSETS: '/assets/:file',
   CONTENT: '/_content/:path',
 } as const
@@ -25,7 +25,7 @@ const ROUTES = {
 const ENDPOINT_MAP: [string, string | null][] = [
   ['/api/', null],
   ['/_content/', ROUTES.CONTENT],
-  ['/apis/', ROUTES.APIS],
+  ['/apis/', ROUTES.API_PROXY],
   ['/assets/', ROUTES.ASSETS],
 ]
 


### PR DESCRIPTION
## Summary
- Replace raw request paths with endpoint templates in Prometheus metric labels to prevent high-cardinality explosion
- API routes (`/api/*`) keep exact path since they're fixed endpoints
- Map-based approach for easy extension

| Path | Label |
|---|---|
| `/docs/guides/installation` | `/docs/:slug` |
| `/apis/petstore/listPets` | `/apis/:slug` |
| `/api/page` | `/api/page` |
| `/api/search` | `/api/search` |
| `/assets/chunk-abc.js` | `/assets/:file` |
| `/_content/docs/intro.mdx` | `/_content/:path` |
| `/llms.txt` | `/llms.txt` |

## Test plan
- [x] 163 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)