### PR TITLE
fix: harden CORS proxy with timeout, size limit, and encoded path check

### DIFF
--- a/packages/chronicle/src/server/api/apis-proxy.ts
+++ b/packages/chronicle/src/server/api/apis-proxy.ts
@@ -3,7 +3,7 @@ import { loadConfig } from '@/lib/config';
 import { loadApiSpecs } from '@/lib/openapi';
 
 const MAX_BODY_SIZE = 10_485_760; // 10 MB
-const UPSTREAM_TIMEOUT_MS = 30_000;
+const UPSTREAM_TIMEOUT_MS = 120_000;
 
 interface ProxyRequest {
   specName: string;

--- a/packages/chronicle/src/server/api/apis-proxy.ts
+++ b/packages/chronicle/src/server/api/apis-proxy.ts
@@ -2,7 +2,7 @@ import { defineHandler, HTTPError } from 'nitro';
 import { loadConfig } from '@/lib/config';
 import { loadApiSpecs } from '@/lib/openapi';
 
-const MAX_BODY_SIZE = 1_048_576; // 1 MB
+const MAX_BODY_SIZE = 10_485_760; // 10 MB
 const UPSTREAM_TIMEOUT_MS = 30_000;
 
 interface ProxyRequest {

--- a/packages/chronicle/src/server/api/apis-proxy.ts
+++ b/packages/chronicle/src/server/api/apis-proxy.ts
@@ -1,4 +1,5 @@
 import { defineHandler, HTTPError } from 'nitro';
+import { StatusCodes } from 'http-status-codes';
 import { loadConfig } from '@/lib/config';
 import { loadApiSpecs } from '@/lib/openapi';
 
@@ -27,12 +28,12 @@ function isPathSafe(p: string): boolean {
 
 export default defineHandler(async event => {
   if (event.req.method !== 'POST') {
-    throw new HTTPError({ status: 405, message: 'Method not allowed' });
+    throw new HTTPError({ status: StatusCodes.METHOD_NOT_ALLOWED, message: 'Method not allowed' });
   }
 
   const contentLength = parseInt(event.req.headers.get('content-length') ?? '0', 10);
   if (contentLength > MAX_BODY_SIZE) {
-    throw new HTTPError({ status: 413, message: `Request body too large (max ${MAX_BODY_SIZE} bytes)` });
+    throw new HTTPError({ status: StatusCodes.CONTENT_TOO_LARGE, message: `Request body too large (max ${MAX_BODY_SIZE} bytes)` });
   }
 
   const { specName, method, path, headers, body } =
@@ -40,7 +41,7 @@ export default defineHandler(async event => {
 
   if (!specName || !method || !path) {
     throw new HTTPError({
-      status: 400,
+      status: StatusCodes.BAD_REQUEST,
       message: 'Missing specName, method, or path'
     });
   }
@@ -50,11 +51,11 @@ export default defineHandler(async event => {
   const spec = specs.find(s => s.name === specName);
 
   if (!spec) {
-    throw new HTTPError({ status: 404, message: `Unknown spec: ${specName}` });
+    throw new HTTPError({ status: StatusCodes.NOT_FOUND, message: `Unknown spec: ${specName}` });
   }
 
   if (!isPathSafe(path)) {
-    throw new HTTPError({ status: 400, message: 'Invalid path' });
+    throw new HTTPError({ status: StatusCodes.BAD_REQUEST, message: 'Invalid path' });
   }
 
   const url = spec.server.url + path;
@@ -86,14 +87,14 @@ export default defineHandler(async event => {
     });
   } catch (error) {
     if (error instanceof DOMException && error.name === 'TimeoutError') {
-      throw new HTTPError({ status: 504, message: `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms` });
+      throw new HTTPError({ status: StatusCodes.GATEWAY_TIMEOUT, message: `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms` });
     }
     const message =
       error instanceof Error
         ? `${error.message}${error.cause ? `: ${(error.cause as Error).message}` : ''}`
         : 'Request failed';
     throw new HTTPError({
-      status: 502,
+      status: StatusCodes.BAD_GATEWAY,
       message: `Could not reach ${url}\n${message}`
     });
   }

--- a/packages/chronicle/src/server/api/apis-proxy.ts
+++ b/packages/chronicle/src/server/api/apis-proxy.ts
@@ -2,6 +2,9 @@ import { defineHandler, HTTPError } from 'nitro';
 import { loadConfig } from '@/lib/config';
 import { loadApiSpecs } from '@/lib/openapi';
 
+const MAX_BODY_SIZE = 1_048_576; // 1 MB
+const UPSTREAM_TIMEOUT_MS = 30_000;
+
 interface ProxyRequest {
   specName: string;
   method: string;
@@ -10,9 +13,26 @@ interface ProxyRequest {
   body?: unknown;
 }
 
+function isPathSafe(p: string): boolean {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(p);
+  } catch {
+    return false;
+  }
+  if (/^[a-z]+:\/\//i.test(decoded)) return false;
+  const normalized = new URL(decoded, 'http://localhost').pathname;
+  return !normalized.split('/').includes('..');
+}
+
 export default defineHandler(async event => {
   if (event.req.method !== 'POST') {
     throw new HTTPError({ status: 405, message: 'Method not allowed' });
+  }
+
+  const contentLength = parseInt(event.req.headers.get('content-length') ?? '0', 10);
+  if (contentLength > MAX_BODY_SIZE) {
+    throw new HTTPError({ status: 413, message: `Request body too large (max ${MAX_BODY_SIZE} bytes)` });
   }
 
   const { specName, method, path, headers, body } =
@@ -33,7 +53,7 @@ export default defineHandler(async event => {
     throw new HTTPError({ status: 404, message: `Unknown spec: ${specName}` });
   }
 
-  if (/^[a-z]+:\/\//i.test(path) || path.includes('..')) {
+  if (!isPathSafe(path)) {
     throw new HTTPError({ status: 400, message: 'Invalid path' });
   }
 
@@ -43,7 +63,8 @@ export default defineHandler(async event => {
     const response = await fetch(url, {
       method,
       headers,
-      body: body ? JSON.stringify(body) : undefined
+      body: body ? JSON.stringify(body) : undefined,
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
     });
 
     const contentType = response.headers.get('content-type') ?? '';
@@ -64,6 +85,9 @@ export default defineHandler(async event => {
       headers: responseHeaders
     });
   } catch (error) {
+    if (error instanceof DOMException && error.name === 'TimeoutError') {
+      throw new HTTPError({ status: 504, message: `Upstream request timed out after ${UPSTREAM_TIMEOUT_MS}ms` });
+    }
     const message =
       error instanceof Error
         ? `${error.message}${error.cause ? `: ${(error.cause as Error).message}` : ''}`


### PR DESCRIPTION
## Summary
- Decode path before traversal check to catch `%2e%2e` encoded variants
- Add `AbortSignal.timeout(30s)` to upstream fetch calls
- Reject request bodies larger than 1MB via `Content-Length` check
- Return 504 for upstream timeouts instead of generic 502

Closes #118

## Test plan
- [ ] Send proxy request with `%2e%2e` in path → should get 400
- [ ] Send proxy request with body > 1MB → should get 413
- [ ] Send proxy request to unreachable host → should timeout with 504 after 30s
- [ ] Normal proxy requests still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)