### PR TITLE
perf: preload API specs fetch in SSR head

### DIFF
--- a/packages/chronicle/src/server/entry-server.tsx
+++ b/packages/chronicle/src/server/entry-server.tsx
@@ -158,6 +158,16 @@ export default {
             const href = isLocalImage(src) && !isSvg(src) ? buildOptimizedUrl(src, DEFAULT_WIDTH) : src;
             return <link key={src} rel="preload" as="image" href={href} />;
           })}
+          {isApiRoute && (
+            <link
+              rel="preload"
+              as="fetch"
+              crossOrigin="anonymous"
+              href={route.version.dir
+                ? `/api/specs?version=${encodeURIComponent(route.version.dir)}`
+                : '/api/specs'}
+            />
+          )}
           <script type="module" src={assets.entry} />
           <script dangerouslySetInnerHTML={{ __html: `window.__PAGE_DATA__ = ${safeJson}` }} />
         </head>


### PR DESCRIPTION
## Summary
- Add `<link rel="preload" as="fetch">` for `/api/specs` in SSR `<head>` on API routes
- Browser starts fetching specs immediately while parsing HTML, overlapping with JS bundle download
- Reduces perceived load time on API page first load

## Test plan
- [x] Build passes (`bun run build:cli`)
- [x] Dev server renders preload link in API page HTML
- [x] Non-API pages unaffected (preload only added when `isApiRoute`)
- [ ] Verify in browser Network tab that `/api/specs` fetch starts before JS execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)