### PR TITLE
fix: fallback to site description for pages without description

### DIFF
--- a/packages/chronicle/src/lib/head.tsx
+++ b/packages/chronicle/src/lib/head.tsx
@@ -9,8 +9,9 @@ export interface HeadProps {
   markdownHref?: string;
 }
 
-export function Head({ title, description, config, jsonLd, markdownHref }: HeadProps) {
+export function Head({ title, description: pageDescription, config, jsonLd, markdownHref }: HeadProps) {
   const { pathname } = useLocation();
+  const description = pageDescription || config.site.description;
   const fullTitle = `${title} | ${config.site.title}`;
   const ogParams = new URLSearchParams({ title });
   if (description) ogParams.set('description', description);


### PR DESCRIPTION
## Summary
- Pages without `description` in frontmatter now fallback to `config.site.description`
- Applies to `<meta name="description">`, `og:description`, and `twitter:description`
- One-line change in `Head` component

## Test plan
- [x] All 180 tests pass
- [x] Pages without frontmatter description get site-level description in meta tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)