### PR TITLE
fix: add upstream timeout and body size limit to API proxy

### DIFF
--- a/packages/chronicle/src/server/api/apis-proxy.ts
+++ b/packages/chronicle/src/server/api/apis-proxy.ts
@@ -41,7 +41,8 @@ export default defineHandler(async event => {
     throw new HTTPError({ status: 404, message: `Unknown spec: ${specName}` });
   }
 
-  if (/^[a-z]+:\/\//i.test(path) || path.includes('..')) {
+  const decoded = decodeURIComponent(path);
+  if (/^[a-z]+:\/\//i.test(decoded) || decoded.includes('..')) {
     throw new HTTPError({ status: 400, message: 'Invalid path' });
   }
 

--- a/packages/chronicle/src/server/api/apis-proxy.ts
+++ b/packages/chronicle/src/server/api/apis-proxy.ts
@@ -10,9 +10,17 @@ interface ProxyRequest {
   body?: unknown;
 }
 
+const MAX_BODY_BYTES = 50 * 1024 * 1024;
+const UPSTREAM_TIMEOUT_MS = 120_000;
+
 export default defineHandler(async event => {
   if (event.req.method !== 'POST') {
     throw new HTTPError({ status: 405, message: 'Method not allowed' });
+  }
+
+  const contentLength = Number(event.req.headers.get('content-length') ?? '0');
+  if (contentLength > MAX_BODY_BYTES) {
+    throw new HTTPError({ status: 413, message: 'Request body too large' });
   }
 
   const { specName, method, path, headers, body } =
@@ -43,7 +51,8 @@ export default defineHandler(async event => {
     const response = await fetch(url, {
       method,
       headers,
-      body: body ? JSON.stringify(body) : undefined
+      body: body ? JSON.stringify(body) : undefined,
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
     });
 
     const contentType = response.headers.get('content-type') ?? '';


### PR DESCRIPTION
## Summary

- Decode path with `decodeURIComponent` before traversal check to catch encoded variants like `%2e%2e`
- Add 2-minute `AbortSignal.timeout` to upstream `fetch()` to prevent indefinitely hanging requests from tying up server workers
- Add 50MB `Content-Length` check before parsing the request body to prevent OOM from oversized payloads

Closes #118