### PR TITLE
fix: drop metrics for unmatched routes to prevent cardinality explosion

### DIFF
--- a/packages/chronicle/src/server/plugins/telemetry.test.ts
+++ b/packages/chronicle/src/server/plugins/telemetry.test.ts
@@ -45,6 +45,12 @@ describe('toEndpoint', () => {
     expect(toEndpoint('/v2/guides/setup')).toBe('/docs/:slug')
   })
 
+  test('bare docs root paths map to /docs/:slug', () => {
+    expect(toEndpoint('/docs')).toBe('/docs/:slug')
+    expect(toEndpoint('/developer')).toBe('/docs/:slug')
+    expect(toEndpoint('/v1')).toBe('/docs/:slug')
+  })
+
   test('scanner/unmatched routes return null', () => {
     expect(toEndpoint('/.env')).toBeNull()
     expect(toEndpoint('/.aws/credentials')).toBeNull()

--- a/packages/chronicle/src/server/plugins/telemetry.test.ts
+++ b/packages/chronicle/src/server/plugins/telemetry.test.ts
@@ -44,10 +44,4 @@ describe('toEndpoint', () => {
     expect(toEndpoint('/v1/docs/intro')).toBe('/docs/:slug')
     expect(toEndpoint('/v2/guides/setup')).toBe('/docs/:slug')
   })
-
-  test('unmatched paths fall through to /docs/:slug', () => {
-    expect(toEndpoint('/.env')).toBe('/docs/:slug')
-    expect(toEndpoint('/wp-config.bak')).toBe('/docs/:slug')
-    expect(toEndpoint('/unknown/path')).toBe('/docs/:slug')
-  })
 })

--- a/packages/chronicle/src/server/plugins/telemetry.test.ts
+++ b/packages/chronicle/src/server/plugins/telemetry.test.ts
@@ -44,4 +44,13 @@ describe('toEndpoint', () => {
     expect(toEndpoint('/v1/docs/intro')).toBe('/docs/:slug')
     expect(toEndpoint('/v2/guides/setup')).toBe('/docs/:slug')
   })
+
+  test('scanner/unmatched routes return null', () => {
+    expect(toEndpoint('/.env')).toBeNull()
+    expect(toEndpoint('/.aws/credentials')).toBeNull()
+    expect(toEndpoint('/wp-config.bak')).toBeNull()
+    expect(toEndpoint('/$(pwd)/.git/config')).toBeNull()
+    expect(toEndpoint('/.circleci/context/secrets.yml')).toBeNull()
+    expect(toEndpoint('/application.properties')).toBeNull()
+  })
 })

--- a/packages/chronicle/src/server/plugins/telemetry.test.ts
+++ b/packages/chronicle/src/server/plugins/telemetry.test.ts
@@ -45,18 +45,9 @@ describe('toEndpoint', () => {
     expect(toEndpoint('/v2/guides/setup')).toBe('/docs/:slug')
   })
 
-  test('bare docs root paths map to /docs/:slug', () => {
-    expect(toEndpoint('/docs')).toBe('/docs/:slug')
-    expect(toEndpoint('/developer')).toBe('/docs/:slug')
-    expect(toEndpoint('/v1')).toBe('/docs/:slug')
-  })
-
-  test('scanner/unmatched routes return null', () => {
-    expect(toEndpoint('/.env')).toBeNull()
-    expect(toEndpoint('/.aws/credentials')).toBeNull()
-    expect(toEndpoint('/wp-config.bak')).toBeNull()
-    expect(toEndpoint('/$(pwd)/.git/config')).toBeNull()
-    expect(toEndpoint('/.circleci/context/secrets.yml')).toBeNull()
-    expect(toEndpoint('/application.properties')).toBeNull()
+  test('unmatched paths fall through to /docs/:slug', () => {
+    expect(toEndpoint('/.env')).toBe('/docs/:slug')
+    expect(toEndpoint('/wp-config.bak')).toBe('/docs/:slug')
+    expect(toEndpoint('/unknown/path')).toBe('/docs/:slug')
   })
 })

--- a/packages/chronicle/src/server/plugins/telemetry.ts
+++ b/packages/chronicle/src/server/plugins/telemetry.ts
@@ -37,13 +37,16 @@ const ENDPOINT_MAP: [string, string | null][] = [
 
 const STATIC_ROUTES = new Set(['/llms.txt', '/robots.txt', '/sitemap.xml', '/og'])
 
-export function toEndpoint(pathname: string): string {
+const DOC_PATH_PREFIX = /^\/(?:docs|developer|v\d+)\//
+
+export function toEndpoint(pathname: string): string | null {
   if (pathname === '/') return ROUTES.ROOT;
   for (const [prefix, template] of ENDPOINT_MAP) {
     if (pathname.startsWith(prefix)) return template ?? pathname;
   }
   if (STATIC_ROUTES.has(pathname)) return pathname;
-  return ROUTES.DOCS;
+  if (DOC_PATH_PREFIX.test(pathname)) return ROUTES.DOCS;
+  return null;
 }
 
 export default definePlugin((nitroApp) => {
@@ -82,7 +85,8 @@ export default definePlugin((nitroApp) => {
   })
 
   nitroApp.hooks.hook('chronicle:ssr-rendered', (route, status, durationMs) => {
-    ssrRenderDuration.record(durationMs, { route: toEndpoint(route), status })
+    const endpoint = toEndpoint(route)
+    if (endpoint) ssrRenderDuration.record(durationMs, { route: endpoint, status })
   })
 
   nitroApp.hooks.hook('request', (event) => {
@@ -103,8 +107,10 @@ export default definePlugin((nitroApp) => {
       event.req.socket?.remoteAddress ??
       'unknown'
 
-    requestCounter.add(1, { method, endpoint, status: res.status })
-    requestDuration.record(duration, { method, endpoint, status: res.status })
+    if (endpoint) {
+      requestCounter.add(1, { method, endpoint, status: res.status })
+      requestDuration.record(duration, { method, endpoint, status: res.status })
+    }
 
     logger.emit({
       severityNumber: SeverityNumber.INFO,

--- a/packages/chronicle/src/server/plugins/telemetry.ts
+++ b/packages/chronicle/src/server/plugins/telemetry.ts
@@ -82,8 +82,8 @@ export default definePlugin((nitroApp) => {
   })
 
   nitroApp.hooks.hook('chronicle:ssr-rendered', (route, status, durationMs) => {
-    if (status === 404) return
-    ssrRenderDuration.record(durationMs, { route: toEndpoint(route), status })
+    const endpoint = status === 404 ? '/api/not-found' : toEndpoint(route)
+    ssrRenderDuration.record(durationMs, { route: endpoint, status })
   })
 
   nitroApp.hooks.hook('request', (event) => {
@@ -96,7 +96,7 @@ export default definePlugin((nitroApp) => {
     const duration = performance.now() - start
     const method = event.req.method
     const route = new URL(event.req.url).pathname
-    const endpoint = toEndpoint(route)
+    const endpoint = res.status === 404 ? '/api/not-found' : toEndpoint(route)
 
     const clientIp =
       event.req.headers['x-forwarded-for']?.toString().split(',')[0].trim() ??
@@ -104,10 +104,8 @@ export default definePlugin((nitroApp) => {
       event.req.socket?.remoteAddress ??
       'unknown'
 
-    if (res.status !== 404) {
-      requestCounter.add(1, { method, endpoint, status: res.status })
-      requestDuration.record(duration, { method, endpoint, status: res.status })
-    }
+    requestCounter.add(1, { method, endpoint, status: res.status })
+    requestDuration.record(duration, { method, endpoint, status: res.status })
 
     logger.emit({
       severityNumber: SeverityNumber.INFO,

--- a/packages/chronicle/src/server/plugins/telemetry.ts
+++ b/packages/chronicle/src/server/plugins/telemetry.ts
@@ -37,7 +37,7 @@ const ENDPOINT_MAP: [string, string | null][] = [
 
 const STATIC_ROUTES = new Set(['/llms.txt', '/robots.txt', '/sitemap.xml', '/og'])
 
-const DOC_PATH_PREFIX = /^\/(?:docs|developer|v\d+)\//
+const DOC_PATH_PREFIX = /^\/(?:docs|developer|v\d+)(?:\/|$)/
 
 export function toEndpoint(pathname: string): string | null {
   if (pathname === '/') return ROUTES.ROOT;

--- a/packages/chronicle/src/server/plugins/telemetry.ts
+++ b/packages/chronicle/src/server/plugins/telemetry.ts
@@ -37,16 +37,13 @@ const ENDPOINT_MAP: [string, string | null][] = [
 
 const STATIC_ROUTES = new Set(['/llms.txt', '/robots.txt', '/sitemap.xml', '/og'])
 
-const DOC_PATH_PREFIX = /^\/(?:docs|developer|v\d+)(?:\/|$)/
-
-export function toEndpoint(pathname: string): string | null {
+export function toEndpoint(pathname: string): string {
   if (pathname === '/') return ROUTES.ROOT;
   for (const [prefix, template] of ENDPOINT_MAP) {
     if (pathname.startsWith(prefix)) return template ?? pathname;
   }
   if (STATIC_ROUTES.has(pathname)) return pathname;
-  if (DOC_PATH_PREFIX.test(pathname)) return ROUTES.DOCS;
-  return null;
+  return ROUTES.DOCS;
 }
 
 export default definePlugin((nitroApp) => {
@@ -85,8 +82,8 @@ export default definePlugin((nitroApp) => {
   })
 
   nitroApp.hooks.hook('chronicle:ssr-rendered', (route, status, durationMs) => {
-    const endpoint = toEndpoint(route)
-    if (endpoint) ssrRenderDuration.record(durationMs, { route: endpoint, status })
+    if (status === 404) return
+    ssrRenderDuration.record(durationMs, { route: toEndpoint(route), status })
   })
 
   nitroApp.hooks.hook('request', (event) => {
@@ -107,7 +104,7 @@ export default definePlugin((nitroApp) => {
       event.req.socket?.remoteAddress ??
       'unknown'
 
-    if (endpoint) {
+    if (res.status !== 404) {
       requestCounter.add(1, { method, endpoint, status: res.status })
       requestDuration.record(duration, { method, endpoint, status: res.status })
     }


### PR DESCRIPTION
## Summary
- Scanner/bot traffic hitting arbitrary paths (e.g. `/.env`, `/.aws/credentials`) creates thousands of unique route label values in metrics
- During attacks this inflated the Mimir tenant from ~230K to 500K+ active series, triggering `per_user_series_limit` discards for all services
- Instead of pattern-matching known routes, we skip metrics for all 404 responses — scanner traffic always 404s, so this eliminates the cardinality problem without maintaining a route allowlist
- Logging is preserved so scanner traffic remains visible for security auditing

Closes #151

## Test plan
- [x] Existing `toEndpoint` tests still pass
- [x] New test verifies unmatched paths still map to `/docs/:slug` (toEndpoint unchanged)
- [ ] Deploy and confirm 404 requests no longer produce metric series