### PR TITLE
fix: prevent inherited text-align justify from distorting table cell text

### DIFF
--- a/packages/chronicle/src/themes/default/Page.module.css
+++ b/packages/chronicle/src/themes/default/Page.module.css
@@ -126,6 +126,8 @@
   table-layout: fixed;
   width: 100%;
   margin-bottom: var(--rs-space-5);
+  /* block inherited justify (e.g. from <p align="justify"> in content) without overriding GFM column alignment */
+  text-align: start;
 }
 
 .content table td,

--- a/packages/chronicle/src/themes/paper/Page.module.css
+++ b/packages/chronicle/src/themes/paper/Page.module.css
@@ -204,6 +204,8 @@
   table-layout: fixed;
   width: 100%;
   margin-bottom: var(--rs-space-5);
+  /* block inherited justify (e.g. from <p align="justify"> in content) without overriding GFM column alignment */
+  text-align: start;
 }
 
 .content table td,


### PR DESCRIPTION
## Problem

When MDX content wraps a table in an element carrying a presentational alignment attribute (e.g. `<p align="justify">`, common in content migrated from other doc tools), the `text-align: justify` inherits into the table. Apsara's `Table.Head` sets an explicit `text-align: left`, but `Table.Cell` declares no `text-align`, so body cells render justified. Any cell whose text wraps gets stretched, uneven word spacing per line.

Observed on docs.pixxel.space, e.g. the [product versions](https://docs.pixxel.space/documentation/satellite_and_imagery/pixxels_imagery/product_versions) page where every multi-line cell shows large gaps between words.

## Fix

Set `text-align: start` on `.content table` in both themes (default and paper). This stops inherited alignment at the table boundary while keeping GFM column alignment (`:---:` / `---:`) working, because remark/mdast emits those as `align` attributes directly on `th`/`td` — a presentational hint declared on the cell itself, which wins over the inherited value.

## Verification

- Reproduced and verified against the pixxel documentation site with the locally built CLI: justified gaps gone, cells read normally.
- Confirmed a cell with `align="center"` still computes `text-align: center` under the new rule.
- `bun test`: 180 pass. Biome reports only pre-existing warnings on untouched lines.

